### PR TITLE
Search overlay Esc key listener

### DIFF
--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -14,10 +14,23 @@ class App extends Component {
       showSearchOverlay: false
     };
     this.updateSearchState = this.updateSearchState.bind(this);
+    this.escFunction = this.escFunction.bind(this);
   }
 
   updateSearchState(enabled) {
     this.setState({ showSearchOverlay: enabled });
+  }
+
+  escFunction(event){
+    if(event.keyCode === 27) {
+      if(this.state.showSearchOverlay) {
+        this.updateSearchState(false);
+      }
+    }
+  }
+
+  componentDidMount(){
+    document.addEventListener("keydown", this.escFunction, false);
   }
 
   render() {

--- a/app/components/App/App.js
+++ b/app/components/App/App.js
@@ -14,14 +14,22 @@ class App extends Component {
       showSearchOverlay: false
     };
     this.updateSearchState = this.updateSearchState.bind(this);
-    this.escFunction = this.escFunction.bind(this);
+    this.onEscKey = this.onEscKey.bind(this);
   }
 
+  /*
+    A function that enables or disables the overlay
+    of the Search function.
+  */
   updateSearchState(enabled) {
     this.setState({ showSearchOverlay: enabled });
   }
 
-  escFunction(event){
+  /*
+    Esc keypress listener. Used for:
+    - Detecting when to close the search overlay
+  */
+  onEscKey(event){
     if(event.keyCode === 27) {
       if(this.state.showSearchOverlay) {
         this.updateSearchState(false);
@@ -30,7 +38,7 @@ class App extends Component {
   }
 
   componentDidMount(){
-    document.addEventListener("keydown", this.escFunction, false);
+    document.addEventListener("keydown", this.onEscKey, false);
   }
 
   render() {


### PR DESCRIPTION
Now we can close the search bar by pressing the Esc button instead of just the X buttom.