### PR TITLE
[FEATURE] Enabled Persistent Notifications

### DIFF
--- a/app/services/notification.js
+++ b/app/services/notification.js
@@ -1,11 +1,13 @@
 import $ from 'jquery';
 
-export function showNotification(message, type = 'danger', position = 'top-right' ) {
+export function showNotification(
+  message, type = 'danger', position = 'top-right', showClose = true ) {
   $('body').pgNotification({
     style: 'bar',
     message: message,
     type: type,
     timeout: type === 'success' ? 3000 : 0,
-    position: position
+    position: position,
+    showClose: showClose
   }).show();
 }


### PR DESCRIPTION
Added an option to the notifications service to enable persistent notifications.

Previous behaviour:
- All notifications could be closed by clicking the X button on them

New behaviour:
- We have an option to hide the X button so that the users cannot dismiss the popup.

@adibas03 I think this will be useful for your PR: https://github.com/chronologic/eth-alarm-clock-dapp/pull/104