### PR TITLE
[FIX] Force new eac.js-lib version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3633,12 +3633,12 @@
       }
     },
     "eac.js-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eac.js-client/-/eac.js-client-2.0.1.tgz",
-      "integrity": "sha512-JMguYi9TlkTaUxgy+2MUW7RbVV7doaWrhUq5d1cMhRWdn73GiZYXAPG6dpQZCL6Ns0C+G9M5Y90W50jGtOY11Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eac.js-client/-/eac.js-client-2.1.0.tgz",
+      "integrity": "sha512-GVnBCB/sScK+11qfzvy2wTLhanhOCTHeff/XwdU4yojT8sAG0hCzInngUVmFBXRkd9lXVVw/Xq4E9pBMQltB5Q==",
       "requires": {
         "bignumber.js": "5.0.0",
-        "eac.js-lib": "1.0.2",
+        "eac.js-lib": "1.1.0",
         "ethereumjs-tx": "1.3.3",
         "ethereumjs-util": "5.1.4",
         "ethereumjs-wallet": "0.6.0",
@@ -3654,9 +3654,9 @@
       }
     },
     "eac.js-lib": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/eac.js-lib/-/eac.js-lib-1.0.2.tgz",
-      "integrity": "sha512-t/aLJ61NgdoIjPswF7BT39ICN7vS863f3wlzGS7/Wbd0uzWWG0CjREfpizDJHdmKnlQ1UES+U0VcNRZKQIct8Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eac.js-lib/-/eac.js-lib-1.1.0.tgz",
+      "integrity": "sha512-qQ8ITddeoLE70/gZejdo27vDzNsMCa7tODoa71Iz4U4awenaFD3e5agowi53DMSDK8U3hWskro16Okw8+Jt12Q==",
       "requires": {
         "bignumber.js": "5.0.0",
         "ethereumjs-util": "5.1.4"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "crypto-js": "^3.1.9-1",
     "dotenv-webpack": "^1.5.4",
     "eac.js-client": "^2.1.0",
-    "eac.js-lib": "^1.0.2",
+    "eac.js-lib": "^1.1.0",
     "ethereumjs-util": "^5.1.4",
     "ethereumjs-wallet": "^0.6.0",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
Forcing the new eac.js-lib version that contains optimisations to reduce the size of our final `app.bundle.js`.

Should increase app performance.