### PR TITLE
[FEATURE] Implement support for websocket endpoints

### DIFF
--- a/app/js/eac-worker.js
+++ b/app/js/eac-worker.js
@@ -1,12 +1,13 @@
 import Web3 from 'web3/index';
+import Web3WsProvider from 'web3-providers-ws';
 import EAC from 'eac.js-lib';
 import EACJSClient from 'eac.js-client';
-import { EAC_WORKER_MESSAGE_TYPES } from './eac-worker-message-types';
-import WorkerLogger from '../lib/worker-logger';
 import Loki from 'lokijs';
 import LokiIndexedAdapter from 'lokijs/src/loki-indexed-adapter.js';
 import BigNumber from 'bignumber.js';
 import { Networks } from '../config/web3Config.js';
+import { EAC_WORKER_MESSAGE_TYPES } from './eac-worker-message-types';
+import WorkerLogger from '../lib/worker-logger';
 
 const { Config, Scanner, StatsDB } = EACJSClient;
 
@@ -19,7 +20,15 @@ class EacWorker {
     let provider = null;
 
     if (network) {
-      provider = new Web3.providers.HttpProvider(network.endpoint);
+      provider = (() => {
+        if ( new RegExp('ws://').test(network.endpoint) || new RegExp('wss://').test(network.endpoint)) {
+          const ws = new Web3WsProvider(`${network.endpoint}`);
+          ws.__proto__.sendAsync = ws.__proto__.send;
+          return ws;
+        } else if ( new RegExp('http://').test(network.endpoint) || new RegExp('https://').test(network.endpoint)) {
+          return new Web3.providers.HttpProvider(`${network.endpoint}`);
+        }
+      })();
     } else {
       provider = new Web3.providers.HttpProvider(process.env.HTTP_PROVIDER);
     }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     "react-spinners": "^0.2.6",
     "select2": "^4.0.4",
     "smooth-scrollbar": "^8.2.6",
-    "web3": "^0.20.0"
+    "web3": "^0.20.0",
+    "web3-providers-ws": "^1.0.0-beta.33"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
set correct timenode endpoint by updating `app>config>web3Config.js` :
https://github.com/chronologic/eth-alarm-clock-dapp/blob/master/app/config/web3Config.js