### PR TITLE
[WIP] [FEATURE] Block activity meter

### DIFF
--- a/app/components/ScheduleWizard/BlockMeterComponent.js
+++ b/app/components/ScheduleWizard/BlockMeterComponent.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+
+class BlockMeterComponent extends Component {
+    render() {
+        return (
+            <div>
+                <meter min="0" max="10" value="1"></meter>
+            </div>
+        );
+    }
+}
+
+export default BlockMeterComponent;

--- a/app/components/ScheduleWizard/TimeSettings/BlockComponent.js
+++ b/app/components/ScheduleWizard/TimeSettings/BlockComponent.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { inject, observer } from 'mobx-react';
 import Bb from 'bluebird';
 import AbstractSetting from '../AbstractSetting';
+import BlockMeterComponent from '../BlockMeterComponent';
 
 const MINIMUM_BLOCK_WINDOW = 16;
 
@@ -67,6 +68,8 @@ class BlockComponent extends AbstractSetting {
               {!_validations.blockNumber &&
                 <label className="error">{_validationsErrors.blockNumber}</label>
                 }
+
+              <BlockMeterComponent blockId={this.blockNumber}/>
             </div>
             <div className="col-md-4">
               <div className={'form-group form-group-default required' + (_validations.blockSize ? '' : ' has-error')}>


### PR DESCRIPTION
This PR aims to implement an meter that will give a rough indicator of how many transactions are scheduled around a scheduled block number and within the neighborhood of e.g.: +/-5 blocks (or more). This will give the user an indicator of if he might need to spend more Gas on his scheduled transaction or not.

![image](https://user-images.githubusercontent.com/160117/38534820-4118b388-3c4e-11e8-9c18-7cc9b35717c7.png)

Reasons to implement this:

- Imagine a highly anticipated ICO going to happen, and many people using Chronos want to get their bid first.
- Will give people idea of whether to spend more on fees.

This is still not well-defined, so ideas and suggestions are welcome.

Brainstorming:

- Cross-reference ICO calendars to weigh in on the meter and show those on the page.

Original idea: EtaCarinae

TODO

- [ ] Define implementation
- [ ] Come up with mockups and designs