### PR TITLE
Changes necessary for the new MobX

### DIFF
--- a/app/services/web3.js
+++ b/app/services/web3.js
@@ -9,10 +9,11 @@ let instance = null;
 export default class Web3Service {
   web3 = null;
   tokenInstance = null;
+  network = null;
+
   @observable initialized = false;
   @observable connectedToMetaMask = null;
   @observable accounts = null;
-  @observable network = null;
   @observable explorer = null;
   @observable latestBlockNumber = null;
 


### PR DESCRIPTION
MobX v5.x makes use of Proxies, and this breaks some functionality in our DApp.
After the upgrade, the `network` object was wrapped in a Proxy function which blocked it from being sent to the WebWorker.

Removing the @observable flag reverted the `network` property back to a POJO and allowed it to be sent to the WebWorker.
The network is not a dynamic object anyway, since it reloads after every change in the DApp, so having the @observable property has no effect, hence it is safe to be removed.

More on the MobX updates: https://github.com/mobxjs/mobx/blob/master/CHANGELOG.md