### PR TITLE
Transfer balance fetching from MetaMask to TimeNode web3 provider

### DIFF
--- a/app/components/TimeNode/TimeNodeMain.js
+++ b/app/components/TimeNode/TimeNodeMain.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import TimeNodeStatistics from './TimeNodeStatistics';
 import TimeNodeLogs from './TimeNodeLogs';
 import TimeNodeSettings from './TimeNodeSettings';
@@ -10,30 +11,52 @@ class TimeNodeMain extends Component {
       <div id="timeNodeMain">
         <ul className="nav nav-tabs nav-tabs-simple" role="tablist">
           <li className="nav-item">
-            <a className="active px-5 py-3" data-toggle="tab" role="tab" data-target="#tabStatistics" href="#">Statistics</a>
+            <a
+              className="active px-5 py-3"
+              data-toggle="tab"
+              role="tab"
+              data-target="#tabStatistics"
+              href="#"
+            >
+              Statistics
+            </a>
           </li>
           <li className="nav-item">
-            <a className="px-5 py-3" href="#" data-toggle="tab" role="tab" data-target="#tabLogs">Logs</a>
+            <a className="px-5 py-3" href="#" data-toggle="tab" role="tab" data-target="#tabLogs">
+              Logs
+            </a>
           </li>
           <li className="nav-item">
-            <a className="px-5 py-3" href="#" data-toggle="tab" role="tab" data-target="#tabSettings">Settings</a>
+            <a
+              className="px-5 py-3"
+              href="#"
+              data-toggle="tab"
+              role="tab"
+              data-target="#tabSettings"
+            >
+              Settings
+            </a>
           </li>
         </ul>
         <div className="tab-content padding-25">
           <div className="tab-pane active" id="tabStatistics">
-            <TimeNodeStatistics/>
+            <TimeNodeStatistics />
           </div>
           <div className="tab-pane " id="tabLogs">
-            <TimeNodeLogs/>
+            <TimeNodeLogs />
           </div>
           <div className="tab-pane " id="tabSettings">
-            <TimeNodeSettings/>
+            <TimeNodeSettings updateWalletUnlocked={this.props.updateWalletUnlocked} />
           </div>
-          <PoweredByEAC/>
+          <PoweredByEAC />
         </div>
       </div>
     );
   }
 }
+
+TimeNodeMain.propTypes = {
+  updateWalletUnlocked: PropTypes.any
+};
 
 export default TimeNodeMain;

--- a/app/components/TimeNode/TimeNodeRoute.js
+++ b/app/components/TimeNode/TimeNodeRoute.js
@@ -24,19 +24,18 @@ class TimeNodeRoute extends Component {
   }
 
   render() {
-    const {
-      walletKeystore,
-      attachedDAYAccount
-    } = this.props.timeNodeStore;
+    const { walletKeystore, attachedDAYAccount } = this.props.timeNodeStore;
 
     const { walletUnlocked } = this.state;
 
     let componentToShow = null;
     if (walletKeystore) {
       if (attachedDAYAccount) {
-        componentToShow = walletUnlocked
-          ? <TimeNodeMain />
-          : <TimeNodeUnlock updateWalletUnlocked={this.updateWalletUnlocked} />;
+        componentToShow = walletUnlocked ? (
+          <TimeNodeMain updateWalletUnlocked={this.updateWalletUnlocked} />
+        ) : (
+          <TimeNodeUnlock updateWalletUnlocked={this.updateWalletUnlocked} />
+        );
       } else {
         componentToShow = <TimeNodeProve />;
       }
@@ -48,7 +47,9 @@ class TimeNodeRoute extends Component {
       <div id="timenodeRoute" className="container padding-25 sm-padding-10 subsection">
         <h1 className="view-title">
           {this.props.timeNodeStore.nodeStatus}&nbsp;
-          <span className="view-subtitle d-none d-md-inline">{this.props.timeNodeStore.getMyAddress()}</span>
+          <span className="view-subtitle d-none d-md-inline">
+            {this.props.timeNodeStore.getMyAddress()}
+          </span>
         </h1>
         <div className="widget-12 card no-border widget-loader-circle no-margin">
           {componentToShow}

--- a/app/components/TimeNode/TimeNodeSettings.js
+++ b/app/components/TimeNode/TimeNodeSettings.js
@@ -12,6 +12,7 @@ class TimeNodeSettings extends Component {
   resetWallet() {
     this.props.timeNodeStore.resetWallet();
     this.props.timeNodeStore.clearStats();
+    this.props.updateWalletUnlocked(false);
   }
 
   render() {
@@ -93,7 +94,8 @@ class TimeNodeSettings extends Component {
 }
 
 TimeNodeSettings.propTypes = {
-  timeNodeStore: PropTypes.any
+  timeNodeStore: PropTypes.any,
+  updateWalletUnlocked: PropTypes.any
 };
 
 export default TimeNodeSettings;

--- a/app/components/TimeNode/TimeNodeStatistics.js
+++ b/app/components/TimeNode/TimeNodeStatistics.js
@@ -98,7 +98,8 @@ class TimeNodeStatistics extends Component {
       profit,
       scanningStarted,
       balanceETH,
-      balanceDAY
+      balanceDAY,
+      executedTransactions
     } = this.props.timeNodeStore;
 
     if (this.state.timeNodeDisabled) {
@@ -158,7 +159,7 @@ class TimeNodeStatistics extends Component {
           <div className="col-md-4">
             <div data-pages="card" className="card card-default">
               <div className="card-header">
-                <div className="card-title">Executed: {this.props.timeNodeStore.totalExecuted}</div>
+                <div className="card-title">Executed: {executedTransactions.length}</div>
                 <div className="card-controls">
                   <ul>
                     <li>
@@ -174,7 +175,7 @@ class TimeNodeStatistics extends Component {
                 </div>
               </div>
               <div ref={el => (this.chartContainer = el)} className="card-body no-padding">
-                {this.props.timeNodeStore.executedTransactions.length > 0 ? (
+                {executedTransactions.length > 0 ? (
                   <ExecutedGraph />
                 ) : (
                   <p className="my-5 text-center">No data yet.</p>
@@ -205,14 +206,14 @@ class TimeNodeStatistics extends Component {
                 <div className="row px-4">
                   <div className="col-6 col-md-6">ETH</div>
                   <div className="col-6 col-md-6">
-                    {balanceETH ? balanceETH : <BeatLoader size={6} />}
+                    {balanceETH !== null ? balanceETH : <BeatLoader size={6} />}
                   </div>
                 </div>
                 <hr className="mt-2 mb-2" />
                 <div className="row px-4 pb-2">
                   <div className="col-6 col-md-6">DAY</div>
                   <div className="col-6 col-md-6">
-                    {balanceDAY ? balanceDAY : <BeatLoader size={6} />}
+                    {balanceDAY !== null ? balanceDAY : <BeatLoader size={6} />}
                   </div>
                 </div>
               </div>

--- a/app/components/TimeNode/TimeNodeStatistics.js
+++ b/app/components/TimeNode/TimeNodeStatistics.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Alert from '../Common/Alert';
 import { TIMENODE_STATUS } from '../../stores/TimeNodeStore';
 import ExecutedGraph from './ExecutedGraph';
+import { BeatLoader } from 'react-spinners';
 
 @inject('timeNodeStore')
 @inject('keenStore')
@@ -20,7 +21,6 @@ class TimeNodeStatistics extends Component {
   }
 
   async UNSAFE_componentWillMount() {
-    await this.refreshBalances();
     this.setState({
       timeNodeDisabled: this.props.timeNodeStore.nodeStatus === TIMENODE_STATUS.DISABLED
     });
@@ -72,15 +72,8 @@ class TimeNodeStatistics extends Component {
       this.props.keenStore.activeTimeNodes > 0 ? this.props.keenStore.activeTimeNodes - 1 : 0;
   }
 
-  async refreshBalances() {
-    await this.props.timeNodeStore.getBalance();
-    await this.props.timeNodeStore.getDAYBalance();
-  }
-
   async refreshStats() {
     this.props.timeNodeStore.updateStats();
-    await this.props.timeNodeStore.getBalance();
-    await this.props.timeNodeStore.getDAYBalance();
   }
 
   getBalanceNotification() {
@@ -99,7 +92,14 @@ class TimeNodeStatistics extends Component {
 
   render() {
     let timeNodeStatus = null;
-    const { bounties, costs, profit, scanningStarted } = this.props.timeNodeStore;
+    const {
+      bounties,
+      costs,
+      profit,
+      scanningStarted,
+      balanceETH,
+      balanceDAY
+    } = this.props.timeNodeStore;
 
     if (this.state.timeNodeDisabled) {
       timeNodeStatus = TIMENODE_STATUS.DISABLED;
@@ -107,7 +107,7 @@ class TimeNodeStatistics extends Component {
       timeNodeStatus = scanningStarted ? 'running' : 'stopped';
     }
 
-    const profitStatus = profit !== null ? profit + ' ETH' : 'Loading...';
+    const profitStatus = profit !== null ? profit + ' ETH' : <BeatLoader />;
     const bountiesStatus =
       bounties !== null && costs !== null ? `${bounties} (bounties) - ${costs} (costs)` : '';
 
@@ -193,7 +193,7 @@ class TimeNodeStatistics extends Component {
                       <a
                         data-toggle="refresh"
                         className="card-refresh"
-                        onClick={() => this.refreshBalances()}
+                        onClick={() => this.refreshStats()}
                       >
                         <i className="card-icon card-icon-refresh" />
                       </a>
@@ -204,12 +204,16 @@ class TimeNodeStatistics extends Component {
               <div className="card-body p-0 m-t-10">
                 <div className="row px-4">
                   <div className="col-6 col-md-6">ETH</div>
-                  <div className="col-6 col-md-6">{this.props.timeNodeStore.balanceETH}</div>
+                  <div className="col-6 col-md-6">
+                    {balanceETH ? balanceETH : <BeatLoader size={6} />}
+                  </div>
                 </div>
                 <hr className="mt-2 mb-2" />
                 <div className="row px-4 pb-2">
                   <div className="col-6 col-md-6">DAY</div>
-                  <div className="col-6 col-md-6">{this.props.timeNodeStore.balanceDAY}</div>
+                  <div className="col-6 col-md-6">
+                    {balanceDAY ? balanceDAY : <BeatLoader size={6} />}
+                  </div>
                 </div>
               </div>
             </div>

--- a/app/js/eac-worker.js
+++ b/app/js/eac-worker.js
@@ -116,11 +116,13 @@ class EacWorker {
    * to which the worker is connected to.
    */
   async getNetworkInfo() {
-    const blockNumber = await Bb.fromCallback(callback => this.web3.eth.getBlockNumber(callback));
+    const providerBlockNumber = await Bb.fromCallback(callback =>
+      this.web3.eth.getBlockNumber(callback)
+    );
 
     postMessage({
       type: EAC_WORKER_MESSAGE_TYPES.GET_NETWORK_INFO,
-      blockNumber
+      providerBlockNumber
     });
   }
 
@@ -189,21 +191,21 @@ class EacWorker {
     DBDeleteRequest.onerror = function() {
       postMessage({
         type: EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS,
-        result: false
+        clearedStats: false
       });
     };
 
     DBDeleteRequest.onsuccess = function() {
       postMessage({
         type: EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS,
-        result: true
+        clearedStats: true
       });
     };
 
     DBDeleteRequest.onblocked = function() {
       postMessage({
         type: EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS,
-        result: false
+        clearedStats: false
       });
     };
   }

--- a/app/lib/timenode-util.js
+++ b/app/lib/timenode-util.js
@@ -1,0 +1,22 @@
+import Bb from 'bluebird';
+
+const getDAYBalance = async (network, web3, address) => {
+  const dayTokenAddress = network.dayTokenAddress;
+  const dayTokenAbi = network.dayTokenAbi;
+
+  const contract = web3.eth.contract(dayTokenAbi).at(dayTokenAddress);
+
+  const balanceNum = await Bb.fromCallback(callback => contract.balanceOf(address, callback));
+  const balanceDAY = web3.fromWei(balanceNum, 'ether');
+
+  const mintingPower =
+    process.env.NODE_ENV === 'docker'
+      ? 0
+      : await Bb.fromCallback(callback => {
+          contract.getMintingPowerByAddress(address, callback);
+        });
+
+  return { balanceDAY, mintingPower };
+};
+
+export { getDAYBalance };

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -308,7 +308,7 @@ export default class TimeNodeStore {
         signature.address
       );
 
-      this.balanceDAY = balanceDAY;
+      this.balanceDAY = balanceDAY.toNumber();
       this.isTimeMint = mintingPower > 0;
 
       const encryptedAttachedAddress = this.encrypt(signature.address);
@@ -343,6 +343,8 @@ export default class TimeNodeStore {
     localStorage.removeItem('attachedDAYAccount');
     this.attachedDAYAccount = '';
     this.walletKeystore = '';
+    this.stopScanning();
+    this.eacWorker = null;
     showNotification('Your wallet has been reset.', 'success');
   }
 

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -114,27 +114,29 @@ export default class TimeNodeStore {
 
     this.eacWorker.onmessage = event => {
       const { type, value } = event.data;
+      const getValuesIfInMessage = values => {
+        values.forEach(value => {
+          if (event.data[value] !== null) {
+            this[value] = event.data[value];
+          }
+        });
+      };
 
       if (type === EAC_WORKER_MESSAGE_TYPES.LOG) {
         this.handleLogMessage(value);
       } else if (type === EAC_WORKER_MESSAGE_TYPES.UPDATE_STATS) {
-        if (event.data.bounties !== null) this.bounties = event.data.bounties;
-        if (event.data.costs !== null) this.costs = event.data.costs;
-        if (event.data.profit !== null) this.profit = event.data.profit;
-        this.executedTransactions = event.data.executedTransactions;
+        getValuesIfInMessage(['bounties', 'costs', 'profit', 'executedTransactions']);
       } else if (type === EAC_WORKER_MESSAGE_TYPES.UPDATE_BALANCES) {
-        if (event.data.balanceETH !== null) this.balanceETH = event.data.balanceETH;
-        if (event.data.balanceDAY !== null) this.balanceDAY = event.data.balanceDAY;
-        if (event.data.isTimeMint !== null) this.isTimeMint = event.data.isTimeMint;
+        getValuesIfInMessage(['balanceETH', 'balanceDAY', 'isTimeMint']);
       } else if (type === EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS) {
-        if (event.data.result) {
+        if (event.data.clearedStats) {
           showNotification('Cleared the stats.', 'success');
           this.updateStats();
         } else {
           showNotification('Unable to clear the stats.', 'danger', 3000);
         }
       } else if (type === EAC_WORKER_MESSAGE_TYPES.GET_NETWORK_INFO) {
-        this.providerBlockNumber = event.data.blockNumber;
+        getValuesIfInMessage(['providerBlockNumber']);
       }
     };
 

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -1,6 +1,5 @@
 import { observable, computed } from 'mobx';
 import CryptoJS from 'crypto-js';
-import Bb from 'bluebird';
 import ethereumJsWallet from 'ethereumjs-wallet';
 
 import EacWorker from 'worker-loader!../js/eac-worker.js';
@@ -8,6 +7,7 @@ import { EAC_WORKER_MESSAGE_TYPES } from '../js/eac-worker-message-types';
 import { showNotification } from '../services/notification';
 import { LOGGER_MSG_TYPES, LOG_TYPE } from '../lib/worker-logger.js';
 import { isMyCryptoSigValid, isSignatureValid, parseSig, SIGNATURE_ERRORS } from '../lib/signature';
+import { getDAYBalance } from '../lib/timenode-util';
 
 /*
  * TimeNode classification based on the number
@@ -41,6 +41,20 @@ export default class TimeNodeStore {
   @observable executedTransactions = [];
   @observable balanceETH = null;
   @observable balanceDAY = null;
+  isTimeMint = null;
+
+  @computed
+  get nodeStatus() {
+    if (this.balance >= 3333) {
+      return TIMENODE_STATUS.MASTER_CHRONONODE;
+    } else if (this.balance >= 888) {
+      return TIMENODE_STATUS.CHRONONODE;
+    } else if (this.balance >= 333 || this.isTimeMint) {
+      return TIMENODE_STATUS.TIMENODE;
+    } else {
+      return TIMENODE_STATUS.DISABLED;
+    }
+  }
 
   @observable bounties = null;
   @observable costs = null;
@@ -84,6 +98,7 @@ export default class TimeNodeStore {
       customProviderUrl: this.customProviderUrl,
       keystore: [this.decrypt(keystore)],
       keystorePassword,
+      dayAccountAddress: this.getAttachedDAYAddress(),
       logfile: 'console',
       logLevel: 1,
       milliseconds: 15000,
@@ -107,6 +122,10 @@ export default class TimeNodeStore {
         if (event.data.costs !== null) this.costs = event.data.costs;
         if (event.data.profit !== null) this.profit = event.data.profit;
         this.executedTransactions = event.data.executedTransactions;
+      } else if (type === EAC_WORKER_MESSAGE_TYPES.UPDATE_BALANCES) {
+        if (event.data.balanceETH !== null) this.balanceETH = event.data.balanceETH;
+        if (event.data.balanceDAY !== null) this.balanceDAY = event.data.balanceDAY;
+        if (event.data.isTimeMint !== null) this.isTimeMint = event.data.isTimeMint;
       } else if (type === EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS) {
         if (event.data.result) {
           showNotification('Cleared the stats.', 'success');
@@ -142,7 +161,7 @@ export default class TimeNodeStore {
   }
 
   sendActiveTimeNodeEvent() {
-    this._keenStore.sendActiveTimeNodeEvent(this.getMyAddress(), this.getMyAttachedAddress());
+    this._keenStore.sendActiveTimeNodeEvent(this.getMyAddress(), this.getAttachedDAYAddress());
   }
 
   async awaitScanReady() {
@@ -236,56 +255,13 @@ export default class TimeNodeStore {
     }
   }
 
-  getMyAttachedAddress() {
+  getAttachedDAYAddress() {
     const encryptedAddress = localStorage.getItem('attachedDAYAccount');
     if (encryptedAddress) {
       return this.decrypt(encryptedAddress);
     } else {
       return '';
     }
-  }
-
-  async getBalance(address = this.getMyAddress()) {
-    const balance = await this._eacService.Util.getBalance(address);
-
-    this.balanceETH = balance
-      .div(10 ** 18)
-      .toNumber()
-      .toFixed(2);
-
-    return this.balanceETH;
-  }
-
-  async getDAYBalance(address = this.getMyAttachedAddress()) {
-    await this._web3Service.init();
-    const web3 = this._web3Service.web3;
-
-    const dayTokenAddress = this._web3Service.network.dayTokenAddress;
-    const dayTokenAbi = this._web3Service.network.dayTokenAbi;
-
-    const contract = web3.eth.contract(dayTokenAbi).at(dayTokenAddress);
-
-    const balanceNum = await Bb.fromCallback(callback => contract.balanceOf(address, callback));
-    const balance = balanceNum
-      .div(10 ** 18)
-      .toNumber()
-      .toFixed(2);
-
-    const mintingPower =
-      process.env.NODE_ENV === 'docker'
-        ? 0
-        : await Bb.fromCallback(callback => {
-            contract.getMintingPowerByAddress(address, callback);
-          });
-
-    this.nodeStatus = this.getNodeStatus(balance, mintingPower > 0);
-    this.balanceDAY = balance;
-
-    if (this.nodeStatus === TIMENODE_STATUS.DISABLED) {
-      this.stopScanning();
-    }
-
-    return balance;
   }
 
   sendMessageWorker(messageType) {
@@ -310,18 +286,6 @@ export default class TimeNodeStore {
     this.detailedLogs = [];
   }
 
-  getNodeStatus(balance, isTimeMint) {
-    if (balance >= 3333) {
-      return TIMENODE_STATUS.MASTER_CHRONONODE;
-    } else if (balance >= 888) {
-      return TIMENODE_STATUS.CHRONONODE;
-    } else if (balance >= 333 || isTimeMint) {
-      return TIMENODE_STATUS.TIMENODE;
-    } else {
-      return TIMENODE_STATUS.DISABLED;
-    }
-  }
-
   /*
    * Attaches a DAY-token-holding account to the session
    * as a proof-of-ownership of DAY tokens.
@@ -336,7 +300,15 @@ export default class TimeNodeStore {
 
       if (!validSig) throw SIGNATURE_ERRORS.INVALID_SIG;
 
-      const numDAYTokens = await this.getDAYBalance(signature.address);
+      const { balanceDAY, mintingPower } = await getDAYBalance(
+        this._web3Service.network,
+        this._web3Service.web3,
+        signature.address
+      );
+
+      this.balanceDAY = balanceDAY;
+      this.isTimeMint = mintingPower > 0;
+
       const encryptedAttachedAddress = this.encrypt(signature.address);
 
       if (this.nodeStatus !== TIMENODE_STATUS.DISABLED) {
@@ -344,7 +316,7 @@ export default class TimeNodeStore {
         this.attachedDAYAccount = encryptedAttachedAddress;
         showNotification('Success.', 'success');
       } else {
-        showNotification('Not enough DAY tokens. Current balance: ' + numDAYTokens.toString());
+        showNotification('Not enough DAY tokens. Current balance: ' + balanceDAY.toString());
       }
     } catch (error) {
       showNotification(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5011,7 +5011,7 @@
       }
     },
     "eac.js-client": {
-      "version": "github:ethereum-alarm-clock/eac.js-client#6c7f5f0490fdcb901d1309ff6fad34b1bdd4df58",
+      "version": "github:ethereum-alarm-clock/eac.js-client#d4710731ff56fc874d5c22a03cb79abd9e25a52a",
       "requires": {
         "@types/bluebird": "3.5.21",
         "@types/es6-promise": "3.3.0",
@@ -10672,9 +10672,9 @@
       }
     },
     "keen-tracking": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/keen-tracking/-/keen-tracking-2.0.2.tgz",
-      "integrity": "sha512-OT6OXxnXQHu+wl7yjZBNh8wPoIPVy61p4wL6Dn50Efv4sIW3+/OSSvXL31k82HGtLmzvVcWt+YabH9XkoRbd4Q==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/keen-tracking/-/keen-tracking-2.0.7.tgz",
+      "integrity": "sha512-bL1QMmGEXvDR0GtkmjiQfQrKl0ubWbqf1kOu/gzyUi/77SIgz7KvdldkAWUfAwhHudz7FA+UnFWnWgTKzKFTew==",
       "requires": {
         "component-emitter": "1.2.1",
         "js-cookie": "2.1.0",
@@ -11910,9 +11910,9 @@
       "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k="
     },
     "moment-timezone": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.20.tgz",
-      "integrity": "sha512-uJXgstE4ddmJpLFIyihm7VsLJsViDxO88lx+GmIbSnyAAHHbSdpwBhpE2N3KFOmDa/9BxYDykQUzH796CHga2w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
       "requires": {
         "moment": "2.22.2"
       }


### PR DESCRIPTION
Solves an issue when the TimeNode would be set to a different provider, it would still fetch balances from the MetaMask provider.

Additional:
- Minor refactors
- Pretty loadbars
- Fixes an issue with showing the incorrect balance upon changing TimeNode wallets
- Fixes a security issue where after changing wallets the TimeNode would not re-ask the wallet password