### PR TITLE
[FIX][TimeNode] Miscellaneous Fixes

### DIFF
--- a/app/components/TimeNode/StatisticsComponents/ActionsTable.js
+++ b/app/components/TimeNode/StatisticsComponents/ActionsTable.js
@@ -58,11 +58,13 @@ class ActionsTable extends Component {
 
     return (
       <div id="actionsTable">
-        <div className="font-montserrat m-r-25 m-b-10" style={{ textAlign: 'right' }}>
-          Showing actions: {pagination.from}-
-          {pagination.to > allActions.length ? allActions.length : pagination.to}/
-          {allActions.length}
-        </div>
+        {allActions.length > 0 && (
+          <div className="font-montserrat m-r-25 m-b-10 text-right">
+            Showing actions: {pagination.from + 1}-
+            {pagination.to > allActions.length ? allActions.length : pagination.to}/
+            {allActions.length}
+          </div>
+        )}
         <div className="auto-overflow" style={{ height: '250px' }}>
           <table className="table table-condensed header-fixed">
             <thead>

--- a/app/components/TimeNode/StatisticsComponents/ActionsTable.js
+++ b/app/components/TimeNode/StatisticsComponents/ActionsTable.js
@@ -127,11 +127,15 @@ class ActionsTable extends Component {
               <ReactPaginate
                 previousClassName={'hide'}
                 nextClassName={'hide'}
-                breakLabel={<a href="">...</a>}
-                breakClassName={'break-me'}
+                breakLabel={
+                  <a href className="actions-pages">
+                    ...
+                  </a>
+                }
+                breakClassName={'btn p-0'}
                 pageCount={numPages}
                 marginPagesDisplayed={2}
-                pageRangeDisplayed={5}
+                pageRangeDisplayed={3}
                 onPageChange={this.changePage}
                 containerClassName={'pagination btn-group mx-4'}
                 pageClassName={'btn p-0'}

--- a/app/components/TimeNode/TimeNodeStatistics.js
+++ b/app/components/TimeNode/TimeNodeStatistics.js
@@ -403,7 +403,7 @@ class TimeNodeStatistics extends Component {
           </div>
         </div>
 
-        <div className="card no-border no-margin widget-loader-bar">
+        <div className="card no-border widget-loader-bar m-b-25">
           <div className="card-header">
             <div className="card-title">Details</div>
             <div className="card-controls">

--- a/app/components/TimeNode/TimeNodeStatistics.js
+++ b/app/components/TimeNode/TimeNodeStatistics.js
@@ -321,14 +321,20 @@ class TimeNodeStatistics extends Component {
               </div>
 
               <div className="auto-overflow">
-                <table className="table table-condensed">
+                <table className="table table-condensed" style={{ 'table-layout': 'fixed' }}>
                   <thead>
                     <tr>
-                      <th />
-                      <th className="font-montserrat all-caps text-warning">
+                      <th style={{ width: '50%' }} />
+                      <th
+                        style={{ width: '25%' }}
+                        className="font-montserrat all-caps text-warning"
+                      >
                         <i className="fas fa-exclamation-triangle" title="Failed execution." />
                       </th>
-                      <th className="font-montserrat all-caps text-success">
+                      <th
+                        style={{ width: '25%' }}
+                        className="font-montserrat all-caps text-success"
+                      >
                         <i className="fa fa-check" title="Successful execution." />
                       </th>
                     </tr>
@@ -336,17 +342,15 @@ class TimeNodeStatistics extends Component {
 
                   <tbody>
                     <tr>
-                      <td style={{ width: '50%' }} className="all-caps">
-                        Executions
-                      </td>
-                      <td style={{ width: '25%' }} className="b-r b-dashed b-grey hint-text small">
+                      <td className="all-caps">Executions</td>
+                      <td className="b-r b-dashed b-grey hint-text small">
                         {this.showLoaderIfNull({
                           value: failedExecutions,
                           loaderSize: 6,
                           array: true
                         })}
                       </td>
-                      <td style={{ width: '25%' }} className="font-montserrat">
+                      <td className="font-montserrat">
                         {this.showLoaderIfNull({
                           value: successfulExecutions,
                           loaderSize: 6,

--- a/app/components/TimeNode/TimeNodeStatistics.js
+++ b/app/components/TimeNode/TimeNodeStatistics.js
@@ -321,7 +321,7 @@ class TimeNodeStatistics extends Component {
               </div>
 
               <div className="auto-overflow">
-                <table className="table table-condensed" style={{ 'table-layout': 'fixed' }}>
+                <table className="table table-condensed" style={{ tableLayout: 'fixed' }}>
                   <thead>
                     <tr>
                       <th style={{ width: '50%' }} />

--- a/app/js/eac-worker.js
+++ b/app/js/eac-worker.js
@@ -183,6 +183,9 @@ class EacWorker {
 
   clearStats() {
     this.config.statsDb.clearAll();
+    postMessage({
+      type: EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS
+    });
   }
 
   async getClaimedNotExecutedTransactions() {

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -257,12 +257,8 @@ export default class TimeNodeStore {
             break;
 
           case EAC_WORKER_MESSAGE_TYPES.CLEAR_STATS:
-            if (event.data.clearedStats) {
-              showNotification('Cleared the stats.', 'success');
-              this.updateStats();
-            } else {
-              showNotification('Unable to clear the stats.', 'danger', 3000);
-            }
+            showNotification('Cleared the stats.', 'success');
+            this.updateStats();
             break;
 
           case EAC_WORKER_MESSAGE_TYPES.GET_NETWORK_INFO:


### PR DESCRIPTION
Fixes:

**1. Dashboard**
- `ACTIONS` table column width responsiveness
- `...` pagination entry leading to `href="#"` instead of being inactive
- Lower margins improvement
- Only show `Showing actions: 1-100/500` when there are some actions, otherwise hide

**2. Stats**
- Fixed `CLEAR_STATS` event not being fired after stats have been cleared