### PR TITLE
[FIX] Exports

### DIFF
--- a/__tests__/ValueDisplay.unit.test.js
+++ b/__tests__/ValueDisplay.unit.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { ValueDisplay } from '../app/components/Common/ValueDisplay';
+import { ValueDisplay } from '../app/components/Common';
 import { Provider } from 'mobx-react';
 import Web3Service from '../app/services/web3';
 import BigNumber from 'bignumber.js';
@@ -26,7 +26,7 @@ describe('ValueDisplay', () => {
       let mockedRender = renderer.create(
         <Provider {...injectables}>
           <ValueDisplay priceInWei={new BigNumber(bignumber)} />
-        </Provider>,
+        </Provider>
       );
 
       let tree = mockedRender.toJSON();

--- a/app/components/Common/ValueDisplay.js
+++ b/app/components/Common/ValueDisplay.js
@@ -9,7 +9,7 @@ const ETHER_UNITS_VALUES_MAPPING = {
 };
 
 @inject('web3Service')
-export class ValueDisplay extends Component {
+class ValueDisplay extends Component {
   render() {
     const { priceInWei } = this.props;
 
@@ -50,4 +50,4 @@ ValueDisplay.propTypes = {
   web3Service: PropTypes.any
 };
 
-export default ValueDisplay;
+export { ValueDisplay };

--- a/app/components/Common/index.js
+++ b/app/components/Common/index.js
@@ -1,6 +1,6 @@
 export { Step } from './Step';
 export { InputField } from './InputField';
-export { ScheduleWizard } from './ScheduleWizard';
 export { AwaitingMining } from './AwaitingMining';
 export { Faucet } from './Faucet';
 export { URLNotFound } from './URLNotFound';
+export { ValueDisplay } from './ValueDisplay';

--- a/app/components/ScheduleWizard/ScheduleRoute.js
+++ b/app/components/ScheduleWizard/ScheduleRoute.js
@@ -2,17 +2,23 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 import { inject, observer } from 'mobx-react';
 import MetamaskComponent from '../Common/MetamaskComponent';
-import ScheduleWizard from './ScheduleWizard';
+import { ScheduleWizard } from './ScheduleWizard';
 
 @inject('web3Service')
 @observer
-export class ScheduleRoute extends MetamaskComponent {
+class ScheduleRoute extends MetamaskComponent {
   render() {
     return (
       <div className="container padding-25 sm-padding-10">
         <h1 className="view-title">Schedule Transaction</h1>
-        <Route render={routeProps => <ScheduleWizard {...Object.assign({ isWeb3Usable: this.isWeb3Usable }, routeProps)} />} />
+        <Route
+          render={routeProps => (
+            <ScheduleWizard {...Object.assign({ isWeb3Usable: this.isWeb3Usable }, routeProps)} />
+          )}
+        />
       </div>
     );
   }
 }
+
+export { ScheduleRoute };

--- a/app/components/ScheduleWizard/ScheduleWizard.js
+++ b/app/components/ScheduleWizard/ScheduleWizard.js
@@ -428,4 +428,4 @@ ScheduleWizard.propTypes = {
   isWeb3Usable: PropTypes.any
 };
 
-export default ScheduleWizard;
+export { ScheduleWizard };

--- a/app/components/TransactionScanner/BlockOrTimeDisplay.js
+++ b/app/components/TransactionScanner/BlockOrTimeDisplay.js
@@ -11,7 +11,7 @@ const INITIAL_STATE = {
 
 @inject('web3Service')
 @inject('eacService')
-export class BlockOrTimeDisplay extends Component {
+class BlockOrTimeDisplay extends Component {
   state = INITIAL_STATE;
 
   _isMounted = false;
@@ -116,4 +116,4 @@ BlockOrTimeDisplay.propTypes = {
   web3Service: PropTypes.any
 };
 
-export default BlockOrTimeDisplay;
+export { BlockOrTimeDisplay };

--- a/app/components/TransactionScanner/TransactionDetails.js
+++ b/app/components/TransactionScanner/TransactionDetails.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject } from 'mobx-react';
 import Alert from '../Common/Alert';
-import { ValueDisplay } from '../Common/ValueDisplay';
+import { ValueDisplay } from '../Common';
 import { BlockOrTimeDisplay } from './BlockOrTimeDisplay';
 import { TRANSACTION_STATUS } from '../../stores/TransactionStore';
 import { showNotification } from '../../services/notification';

--- a/app/components/TransactionScanner/TransactionRow.js
+++ b/app/components/TransactionScanner/TransactionRow.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject } from 'mobx-react';
 import moment from 'moment';
-import ValueDisplay from '../Common/ValueDisplay';
+import { ValueDisplay } from '../Common';
 import { Link } from 'react-router-dom';
 import { CONFIG } from '../../lib/consts';
 import { TRANSACTION_STATUS } from '../../stores/TransactionStore';

--- a/app/components/TransactionsRoute/TransactionsCompleted.js
+++ b/app/components/TransactionsRoute/TransactionsCompleted.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import NetworkUnsupported from '../Common/NetworkUnsupported';
 
 @inject('featuresService')
-export default class TransactionsCompleted extends Component {
+class TransactionsCompleted extends Component {
   render() {
     const { isCurrentNetworkSupported } = this.props.featuresService;
 
@@ -14,11 +14,7 @@ export default class TransactionsCompleted extends Component {
         <h1 className="view-title">Transaction Scanner - Completed</h1>
         <div className="widget-12 card no-border widget-loader-circle no-margin">
           {isCurrentNetworkSupported !== false ? (
-            <TransactionScanner
-              showStatus
-              includeResolved
-              pastHours={24}
-            />
+            <TransactionScanner showStatus includeResolved pastHours={24} />
           ) : (
             <div className="tab-content p-1 pl-4 pt-4">
               <div className="tab-pane active">
@@ -35,3 +31,5 @@ export default class TransactionsCompleted extends Component {
 TransactionsCompleted.propTypes = {
   featuresService: PropTypes.any
 };
+
+export default TransactionsCompleted;

--- a/app/components/TransactionsRoute/TransactionsOwner.js
+++ b/app/components/TransactionsRoute/TransactionsOwner.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import NetworkUnsupported from '../Common/NetworkUnsupported';
 
 @inject('featuresService')
-export default class TransactionsOwner extends PureComponent {
+class TransactionsOwner extends PureComponent {
   render() {
     const { isCurrentNetworkSupported } = this.props.featuresService;
     const ownerAddress = this.props.match.params.ownerAddress;
@@ -15,17 +15,14 @@ export default class TransactionsOwner extends PureComponent {
         <h1 className="view-title">Transactions by {ownerAddress}</h1>
         <div className="widget-12 card no-border widget-loader-circle no-margin">
           {isCurrentNetworkSupported !== false ? (
-            <TransactionScanner
-              showStatus
-              ownerAddress={ownerAddress}
-            />
+            <TransactionScanner showStatus ownerAddress={ownerAddress} />
           ) : (
-              <div className="tab-content p-1 pl-4 pt-4">
-                <div className="tab-pane active">
-                  <NetworkUnsupported />
-                </div>
+            <div className="tab-content p-1 pl-4 pt-4">
+              <div className="tab-pane active">
+                <NetworkUnsupported />
               </div>
-            )}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -37,3 +34,5 @@ TransactionsOwner.propTypes = {
   location: PropTypes.any,
   match: PropTypes.any
 };
+
+export default TransactionsOwner;

--- a/app/components/TransactionsRoute/TransactionsScheduled.js
+++ b/app/components/TransactionsRoute/TransactionsScheduled.js
@@ -5,7 +5,7 @@ import NetworkUnsupported from '../Common/NetworkUnsupported';
 import PropTypes from 'prop-types';
 
 @inject('featuresService')
-export default class TransactionsScheduled extends Component {
+class TransactionsScheduled extends Component {
   render() {
     const { isCurrentNetworkSupported } = this.props.featuresService;
 
@@ -31,3 +31,5 @@ export default class TransactionsScheduled extends Component {
 TransactionsScheduled.propTypes = {
   featuresService: PropTypes.any
 };
+
+export default TransactionsScheduled;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-alarm-clock-dapp",
-  "version": "1.0.0-rc.3",
+  "version": "1.0.0-rc.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17,47 +17,6 @@
       "dev": true,
       "requires": {
         "@babel/highlight": "7.0.0-beta.44"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
-          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-          "dev": true
-        }
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.44",
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
       }
     },
     "@babel/helper-module-imports": {
@@ -87,15 +46,6 @@
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
       }
     },
     "@babel/highlight": {
@@ -151,77 +101,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
       "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
       "dev": true
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/generator": "7.0.0-beta.44",
-        "@babel/helper-function-name": "7.0.0-beta.44",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "debug": "3.1.0",
-        "globals": "11.7.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-          "dev": true
-        },
-        "globals": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
-          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "2.0.0"
-      },
-      "dependencies": {
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
-      }
     },
     "@compone/class": {
       "version": "1.1.1",
@@ -996,38 +875,6 @@
       "integrity": "sha512-PZJspzAqB0+z60OalXChP9I05BzODd/ffDz6RvTmDG3qclr7YrnpqzvPF+T7vGVtk2nN7syuveTQROJfXcB8xA==",
       "dev": true
     },
-    "app-builder-lib": {
-      "version": "20.28.1",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.28.1.tgz",
-      "integrity": "sha512-OjPTarC27/P3312dNu8N6k2X1r6QGr/q243+bM+DnXddZ6qZQQDsxJz5ONW8b1chRErTUZDRaKQ8RdAYjUIbxw==",
-      "dev": true,
-      "requires": {
-        "7zip-bin": "4.0.2",
-        "app-builder-bin": "2.1.2",
-        "async-exit-hook": "2.0.1",
-        "bluebird-lst": "1.0.5",
-        "builder-util": "6.1.1",
-        "builder-util-runtime": "4.4.1",
-        "chromium-pickle-js": "0.2.0",
-        "debug": "3.1.0",
-        "ejs": "2.6.1",
-        "electron-osx-sign": "0.4.10",
-        "electron-publish": "20.28.0",
-        "fs-extra-p": "4.6.1",
-        "hosted-git-info": "2.7.1",
-        "is-ci": "1.2.0",
-        "isbinaryfile": "3.0.3",
-        "js-yaml": "3.12.0",
-        "lazy-val": "1.0.3",
-        "minimatch": "3.0.4",
-        "normalize-package-data": "2.4.0",
-        "plist": "3.0.1",
-        "read-config-file": "3.1.2",
-        "sanitize-filename": "1.6.1",
-        "semver": "5.5.1",
-        "temp-file": "3.1.3"
-      }
-    },
     "append-transform": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
@@ -1389,7 +1236,7 @@
       "integrity": "sha512-kk4Zb6RUc58ld7gdosERHMF3DzIYJc2fp5sX46qEsGXQQy5bXsu8qyLjoxuY1NuQ/cJuCYnx99BfjwnRggrYIw==",
       "dev": true,
       "requires": {
-        "browserslist": "4.1.0",
+        "browserslist": "4.1.1",
         "caniuse-lite": "1.0.30000885",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
@@ -1467,23 +1314,183 @@
       }
     },
     "babel-eslint": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
+        "@babel/code-frame": "7.0.0",
+        "@babel/parser": "7.0.0",
+        "@babel/traverse": "7.0.0",
+        "@babel/types": "7.0.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "1.0.0"
       },
       "dependencies": {
-        "babylon": {
-          "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-          "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
+          "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0",
+            "jsesc": "2.5.1",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
+          "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "7.0.0",
+            "@babel/template": "7.0.0",
+            "@babel/types": "7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+          "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+          "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.0.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.4.1",
+            "esutils": "2.0.2",
+            "js-tokens": "4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
+          "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
+          "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "@babel/parser": "7.0.0",
+            "@babel/types": "7.0.0"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
+          "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "@babel/generator": "7.0.0",
+            "@babel/helper-function-name": "7.0.0",
+            "@babel/helper-split-export-declaration": "7.0.0",
+            "@babel/parser": "7.0.0",
+            "@babel/types": "7.0.0",
+            "debug": "3.1.0",
+            "globals": "11.7.0",
+            "lodash": "4.17.10"
+          }
+        },
+        "@babel/types": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
+          "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "2.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.3"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
         }
       }
@@ -3115,14 +3122,22 @@
       }
     },
     "browserslist": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
-      "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.1.tgz",
+      "integrity": "sha512-VBorw+tgpOtZ1BYhrVSVTzTt/3+vSE3eFUh0N2GCFK1HffceOaf32YS/bs6WiFhjDAblAFrx85jMy3BG9fBK2Q==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000883",
+        "caniuse-lite": "1.0.30000885",
         "electron-to-chromium": "1.3.62",
         "node-releases": "1.0.0-alpha.11"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30000885",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+          "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
+          "dev": true
+        }
       }
     },
     "bs58": {
@@ -3259,81 +3274,6 @@
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
-    },
-    "builder-util": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-6.1.1.tgz",
-      "integrity": "sha512-n+ah8X8H+DU1YPQHCW9ayLb2g8+KENtRfPtIei0UiqP7p+pURKzL3/sMsxmu4S7mbGQBHV8R6PMu/axBjxy+Ow==",
-      "dev": true,
-      "requires": {
-        "7zip-bin": "4.0.2",
-        "app-builder-bin": "2.1.2",
-        "bluebird-lst": "1.0.5",
-        "builder-util-runtime": "4.4.1",
-        "chalk": "2.4.1",
-        "debug": "3.1.0",
-        "fs-extra-p": "4.6.1",
-        "is-ci": "1.2.0",
-        "js-yaml": "3.12.0",
-        "lazy-val": "1.0.3",
-        "semver": "5.5.1",
-        "source-map-support": "0.5.9",
-        "stat-mode": "0.2.2",
-        "temp-file": "3.1.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "source-map-support": {
-          "version": "0.5.9",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
-      }
     },
     "builder-util-runtime": {
       "version": "4.4.1",
@@ -5070,6 +5010,46 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "default-gateway": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-2.7.2.tgz",
+      "integrity": "sha512-lAc4i9QJR0YHSDFdzeBQKfZ1SRDG3hsJNEkrpcZa8QhBfidLAilT60BDEIVUUGqosFp425KOgB3uYqcnQrWafQ==",
+      "dev": true,
+      "requires": {
+        "execa": "0.10.0",
+        "ip-regex": "2.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.5.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
+      }
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -5328,22 +5308,6 @@
       "integrity": "sha512-Y8ph/85fEChtSgSgw1asP4cGLNLxlbnDBnQMpX8+MOpaiYyOn8assnSpIrwHuoGZV/sE1DUbKh9aeKlWZdHKEg==",
       "dev": true
     },
-    "dmg-builder": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-5.3.0.tgz",
-      "integrity": "sha512-vzjrc7UmPQ+rb4tH8wbQdMq6Fu9M5chFndzhK2831xIpRsRlNlGEIWMiFRZ/MlboVL0vWxG0/2JCd2YMAevEpA==",
-      "dev": true,
-      "requires": {
-        "app-builder-lib": "20.28.1",
-        "bluebird-lst": "1.0.5",
-        "builder-util": "6.1.1",
-        "fs-extra-p": "4.6.1",
-        "iconv-lite": "0.4.24",
-        "js-yaml": "3.12.0",
-        "parse-color": "1.0.0",
-        "sanitize-filename": "1.6.1"
-      }
-    },
     "dns-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
@@ -5579,17 +5543,17 @@
       }
     },
     "electron-builder": {
-      "version": "20.28.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.28.1.tgz",
-      "integrity": "sha512-OKj107B2fV0ftOFOjQLyuKl6n+R8KJOGgGUrHaW4EI8bwqycTq67bgCc0xwPruHBWDX/Kg3tMYBRLbjUNw+6Qw==",
+      "version": "20.28.4",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-20.28.4.tgz",
+      "integrity": "sha512-JMOzMfx9BrC9SJr6+UacuvQZmuodL02Zua8iFn0l5bv32GkWcNj1D6FwybV33BpsmdQ8sF1SkQj+7L+FEIxang==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "20.28.1",
+        "app-builder-lib": "20.28.4",
         "bluebird-lst": "1.0.5",
-        "builder-util": "6.1.1",
+        "builder-util": "6.1.3",
         "builder-util-runtime": "4.4.1",
         "chalk": "2.4.1",
-        "dmg-builder": "5.3.0",
+        "dmg-builder": "5.3.1",
         "fs-extra-p": "4.6.1",
         "is-ci": "1.2.0",
         "lazy-val": "1.0.3",
@@ -5612,6 +5576,60 @@
           "dev": true,
           "requires": {
             "color-convert": "1.9.3"
+          }
+        },
+        "app-builder-lib": {
+          "version": "20.28.4",
+          "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-20.28.4.tgz",
+          "integrity": "sha512-RY4/NJs1HCFWAOpLMivuDzbesU5VyaZVKuQllxgCNZ56+ihgO5aGexla2DVjG/bBQleWfF3DPnEsF3sbZPlpHw==",
+          "dev": true,
+          "requires": {
+            "7zip-bin": "4.0.2",
+            "app-builder-bin": "2.1.2",
+            "async-exit-hook": "2.0.1",
+            "bluebird-lst": "1.0.5",
+            "builder-util": "6.1.3",
+            "builder-util-runtime": "4.4.1",
+            "chromium-pickle-js": "0.2.0",
+            "debug": "3.1.0",
+            "ejs": "2.6.1",
+            "electron-osx-sign": "0.4.10",
+            "electron-publish": "20.28.3",
+            "fs-extra-p": "4.6.1",
+            "hosted-git-info": "2.7.1",
+            "is-ci": "1.2.0",
+            "isbinaryfile": "3.0.3",
+            "js-yaml": "3.12.0",
+            "lazy-val": "1.0.3",
+            "minimatch": "3.0.4",
+            "normalize-package-data": "2.4.0",
+            "plist": "3.0.1",
+            "read-config-file": "3.1.2",
+            "sanitize-filename": "1.6.1",
+            "semver": "5.5.1",
+            "temp-file": "3.1.3"
+          }
+        },
+        "builder-util": {
+          "version": "6.1.3",
+          "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-6.1.3.tgz",
+          "integrity": "sha512-MXeARNff9KHlzJYGJcAhLI/tpE57PmUnleaYfL22IE+viRt192Yr3wQL444ztsA+LUHJ8d12moUoG00jh1hfLA==",
+          "dev": true,
+          "requires": {
+            "7zip-bin": "4.0.2",
+            "app-builder-bin": "2.1.2",
+            "bluebird-lst": "1.0.5",
+            "builder-util-runtime": "4.4.1",
+            "chalk": "2.4.1",
+            "debug": "3.1.0",
+            "fs-extra-p": "4.6.1",
+            "is-ci": "1.2.0",
+            "js-yaml": "3.12.0",
+            "lazy-val": "1.0.3",
+            "semver": "5.5.1",
+            "source-map-support": "0.5.9",
+            "stat-mode": "0.2.2",
+            "temp-file": "3.1.3"
           }
         },
         "camelcase": {
@@ -5651,6 +5669,37 @@
             "xregexp": "4.0.0"
           }
         },
+        "dmg-builder": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-5.3.1.tgz",
+          "integrity": "sha512-/+vtqlgvTtha/4Gc76XIRKS2KzYO58sTWXhZ/kgfNr05ZXY6bIw26v7xDu8ZBpTYnfWI09JRZTMv1yIXT/vvfg==",
+          "dev": true,
+          "requires": {
+            "app-builder-lib": "20.28.4",
+            "bluebird-lst": "1.0.5",
+            "builder-util": "6.1.3",
+            "fs-extra-p": "4.6.1",
+            "iconv-lite": "0.4.24",
+            "js-yaml": "3.12.0",
+            "parse-color": "1.0.0",
+            "sanitize-filename": "1.6.1"
+          }
+        },
+        "electron-publish": {
+          "version": "20.28.3",
+          "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.28.3.tgz",
+          "integrity": "sha512-/2t5zk9EKgH7p7rFZ+ynTKLmpKGF9bktMP2UR6u4bbPz9w4r3WEUbPOeZ1TLqUCAqdfZECcj4ThjrlcAJTghCA==",
+          "dev": true,
+          "requires": {
+            "bluebird-lst": "1.0.5",
+            "builder-util": "6.1.3",
+            "builder-util-runtime": "4.4.1",
+            "chalk": "2.4.1",
+            "fs-extra-p": "4.6.1",
+            "lazy-val": "1.0.3",
+            "mime": "2.3.1"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -5681,6 +5730,12 @@
             "p-locate": "3.0.0",
             "path-exists": "3.0.0"
           }
+        },
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
@@ -5722,6 +5777,22 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -6018,64 +6089,6 @@
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
-          }
-        }
-      }
-    },
-    "electron-publish": {
-      "version": "20.28.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-20.28.0.tgz",
-      "integrity": "sha512-ZGwzXyWuEGIvaCCGD0tebhjYGf7lxjdmkFAW3oFjRXOBXsBl91elOzOwfRSs/7zUE9mvvE0MnyJeBlqO7SAUvA==",
-      "dev": true,
-      "requires": {
-        "bluebird-lst": "1.0.5",
-        "builder-util": "6.1.1",
-        "builder-util-runtime": "4.4.1",
-        "chalk": "2.4.1",
-        "fs-extra-p": "4.6.1",
-        "lazy-val": "1.0.3",
-        "mime": "2.3.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "mime": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
           }
         }
       }
@@ -10273,15 +10286,6 @@
         }
       }
     },
-    "internal-ip": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
-      "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-      "dev": true,
-      "requires": {
-        "meow": "3.7.0"
-      }
-    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -10307,6 +10311,12 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
@@ -22607,9 +22617,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.6.tgz",
-      "integrity": "sha512-uc6YP0DzzW4870TDKoK73uONytLgu27h+x6XfgSvERRChkpd5Ils7US6d5k22LBoh0sDkmPZ6ERHSsrkwtkFFQ==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.1.7.tgz",
+      "integrity": "sha512-KagFrNHf3QKndS61cXqzkQ4gpdXo0d1LZTTplAJzNK1Ev2ZyJiu+BzerW/2dixYYfpnGzp0AcvCXpmYXIOkFOA==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -22623,12 +22633,13 @@
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.18.0",
         "import-local": "1.0.0",
-        "internal-ip": "1.2.0",
+        "internal-ip": "3.0.1",
         "ip": "1.1.5",
         "killable": "1.0.0",
         "loglevel": "1.6.1",
         "opn": "5.3.0",
         "portfinder": "1.0.17",
+        "schema-utils": "1.0.0",
         "selfsigned": "1.10.3",
         "serve-index": "1.9.1",
         "sockjs": "0.3.19",
@@ -22641,6 +22652,18 @@
         "yargs": "12.0.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.5.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
+          "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "2.0.1",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -22907,6 +22930,12 @@
             }
           }
         },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+          "dev": true
+        },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -22987,6 +23016,16 @@
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
+        "internal-ip": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-3.0.1.tgz",
+          "integrity": "sha512-NXXgESC2nNVtU+pqmC9e6R8B1GpKxzsAQhffvh5AL79qKnodd+L7tnEQmTiUAVngqLalPbSqRA7XGIEL5nCd0Q==",
+          "dev": true,
+          "requires": {
+            "default-gateway": "2.7.2",
+            "ipaddr.js": "1.8.0"
+          }
+        },
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
@@ -23061,6 +23100,12 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "kind-of": {
@@ -23146,6 +23191,17 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+          "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+          "dev": true,
+          "requires": {
+            "ajv": "6.5.3",
+            "ajv-errors": "1.0.0",
+            "ajv-keywords": "3.2.0"
+          }
         },
         "string-width": {
           "version": "2.1.1",


### PR DESCRIPTION
Tests now fail in cases where the `export` command is inserted between a class name and a decorator:

```/home/travis/build/chronologic/[secure]/app/components/Common/ValueDisplay.js
  12:1  error  Parsing error: Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead.
  10 | 
  11 | @inject('web3Service')
> 12 | export class ValueDisplay extends Component {
     | ^
  13 |   render() {
  14 |     const { priceInWei } = this.props;
  15 |```

Excerpt from a travis build fail: https://travis-ci.org/chronologic/eth-alarm-clock-dapp/builds/425233694?utm_source=github_status&utm_medium=notification