### PR TITLE
Changes providerUrl -> providerUrls

### DIFF
--- a/app/js/eac-worker.js
+++ b/app/js/eac-worker.js
@@ -49,7 +49,7 @@ class EacWorker {
     }
 
     this.config = new Config({
-      providerUrl,
+      providerUrls: [providerUrl],
       claiming: options.claiming,
       scanSpread: options.scan,
       logfile: options.logfile,


### PR DESCRIPTION
Depends on latest release of `timenode-core`, makes DApp compatible with the change in the config parameters.