### PR TITLE
[FEATURE] Processed Transactions Graph

### DIFF
--- a/app/components/TimeNode/Network/ProcessedTransactionsGraph.js
+++ b/app/components/TimeNode/Network/ProcessedTransactionsGraph.js
@@ -3,17 +3,13 @@ import { inject, observer } from 'mobx-react';
 import PropTypes from 'prop-types';
 import { Chart } from 'chart.js';
 
-const INITIAL_CURRENCY_DENOMINATION = 'ETH';
-
 @inject('timeNodeStore')
-@inject('web3Service')
 @observer
-class TimeBountiesGraph extends Component {
+class ProcessedTransactionsGraph extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      chart: null,
-      currencyDenomination: INITIAL_CURRENCY_DENOMINATION
+      chart: null
     };
     this.setChart = this.setChart.bind(this);
     this.updateChart = this.updateChart.bind(this);
@@ -32,24 +28,7 @@ class TimeBountiesGraph extends Component {
 
   refreshChart() {
     if (this.props.data) {
-      const { web3Service } = this.props;
       let { labels, values } = this.props.data;
-
-      // Chart.js has issues if all numbers are lower than 0.00001
-      // If that is the case, convert the number representation to GWei
-      if (values.every(value => value < 1e-5)) {
-        const valuesInGwei = [];
-
-        values.forEach(value => {
-          const wei = web3Service.web3.toWei(value, 'ether');
-          valuesInGwei.push(web3Service.web3.fromWei(wei, 'gwei'));
-        });
-        values = valuesInGwei;
-
-        this.setState({ currencyDenomination: 'Gwei' });
-      } else if (this.state.currencyDenomination !== INITIAL_CURRENCY_DENOMINATION) {
-        this.setState({ currencyDenomination: INITIAL_CURRENCY_DENOMINATION });
-      }
 
       const data = {
         labels,
@@ -59,7 +38,7 @@ class TimeBountiesGraph extends Component {
       if (this.state.chart !== null) {
         this.updateChart(data);
       } else {
-        this.setChart(this.timeBountiesGraph.getContext('2d'), data);
+        this.setChart(this.processedTransactionsGraph.getContext('2d'), data);
       }
     }
   }
@@ -72,7 +51,7 @@ class TimeBountiesGraph extends Component {
           labels: data.labels,
           datasets: [
             {
-              label: 'Average TimeBounty',
+              label: 'Processed Transactions',
               data: data.values,
               backgroundColor: 'rgba(33, 255, 255, 0.2)',
               borderColor: 'rgba(33, 255, 255, 1)',
@@ -87,10 +66,6 @@ class TimeBountiesGraph extends Component {
                 ticks: {
                   min: 0,
                   beginAtZero: true
-                },
-                scaleLabel: {
-                  display: true,
-                  labelString: this.state.currencyDenomination
                 }
               }
             ]
@@ -117,13 +92,14 @@ class TimeBountiesGraph extends Component {
   }
 
   render() {
-    return <canvas id="timeBountiesGraph" ref={el => (this.timeBountiesGraph = el)} />;
+    return (
+      <canvas id="processedTransactionsGraph" ref={el => (this.processedTransactionsGraph = el)} />
+    );
   }
 }
 
-TimeBountiesGraph.propTypes = {
-  data: PropTypes.any,
-  web3Service: PropTypes.any
+ProcessedTransactionsGraph.propTypes = {
+  data: PropTypes.any
 };
 
-export { TimeBountiesGraph };
+export { ProcessedTransactionsGraph };

--- a/app/components/TimeNode/Network/index.js
+++ b/app/components/TimeNode/Network/index.js
@@ -1,2 +1,3 @@
 export { ActiveTimeNodesGraph } from './ActiveTimeNodesGraph';
 export { TimeBountiesGraph } from './TimeBountiesGraph';
+export { ProcessedTransactionsGraph } from './ProcessedTransactionsGraph';

--- a/app/components/TimeNode/TimeNodeNetwork.js
+++ b/app/components/TimeNode/TimeNodeNetwork.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react';
-import { ActiveTimeNodesGraph, TimeBountiesGraph } from './Network';
+import { ActiveTimeNodesGraph, TimeBountiesGraph, ProcessedTransactionsGraph } from './Network';
 import { BeatLoader } from 'react-spinners';
 
 @inject('keenStore')
@@ -13,13 +13,20 @@ class TimeNodeNetwork extends Component {
   }
 
   render() {
-    const { bountiesGraphData, updatingBountiesGraphInProgress } = this.props.timeNodeStore;
+    const {
+      bountiesGraphData,
+      updatingBountiesGraphInProgress,
+      processedTxs
+    } = this.props.timeNodeStore;
     const { historyActiveTimeNodes, gettingActiveTimeNodesHistory } = this.props.keenStore;
 
     const shouldShowActiveTimeNodesGraph =
       historyActiveTimeNodes.length > 0 && !gettingActiveTimeNodesHistory;
+
     const shouldShowTimeBountiesGraph =
       bountiesGraphData !== null && !updatingBountiesGraphInProgress;
+
+    const shouldShowProcessedTxsGraph = processedTxs !== null;
 
     return (
       <div id="timeNodeNetwork">
@@ -79,6 +86,36 @@ class TimeNodeNetwork extends Component {
               </div>
               <div className="card-body horizontal-center">
                 <TimeBountiesGraph data={this.deepCopy(bountiesGraphData)} />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="row">
+          <div className="col-md-6">
+            <div data-pages="card" className="card card-default">
+              <div className="card-header">
+                <div className="card-title">Processed Transactions (last 24h)</div>
+                <div className="card-controls">
+                  <ul>
+                    <li>
+                      {shouldShowProcessedTxsGraph ? (
+                        <a
+                          data-toggle="refresh"
+                          className="card-refresh"
+                          onClick={() => this.props.timeNodeStore.updateProcessedTxsGraph()}
+                        >
+                          <i className="card-icon card-icon-refresh" />
+                        </a>
+                      ) : (
+                        <BeatLoader size={6} />
+                      )}
+                    </li>
+                  </ul>
+                </div>
+              </div>
+              <div className="card-body horizontal-center">
+                <ProcessedTransactionsGraph data={this.deepCopy(processedTxs)} />
               </div>
             </div>
           </div>

--- a/app/components/TimeNode/TimeNodeNetwork.js
+++ b/app/components/TimeNode/TimeNodeNetwork.js
@@ -16,7 +16,8 @@ class TimeNodeNetwork extends Component {
     const {
       bountiesGraphData,
       updatingBountiesGraphInProgress,
-      processedTxs
+      processedTxs,
+      updatingProcessedTxsGraphInProgress
     } = this.props.timeNodeStore;
     const { historyActiveTimeNodes, gettingActiveTimeNodesHistory } = this.props.keenStore;
 
@@ -26,7 +27,8 @@ class TimeNodeNetwork extends Component {
     const shouldShowTimeBountiesGraph =
       bountiesGraphData !== null && !updatingBountiesGraphInProgress;
 
-    const shouldShowProcessedTxsGraph = processedTxs !== null;
+    const shouldShowProcessedTxsGraph =
+      processedTxs !== null && !updatingProcessedTxsGraphInProgress;
 
     return (
       <div id="timeNodeNetwork">

--- a/app/js/eac-worker-message-types.js
+++ b/app/js/eac-worker-message-types.js
@@ -9,5 +9,6 @@ export const EAC_WORKER_MESSAGE_TYPES = {
   CLEAR_STATS: 'clear-stats',
   GET_CLAIMED_NOT_EXECUTED_TRANSACTIONS: 'get-claimed-not-executed-transactions',
   RECEIVED_CLAIMED_NOT_EXECUTED_TRANSACTIONS: 'received-claimed-not-executed-transactions',
-  BOUNTIES_GRAPH_DATA: 'bounties-graph-data'
+  BOUNTIES_GRAPH_DATA: 'bounties-graph-data',
+  PROCESSED_TXS: 'processed-transactions'
 };

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -160,6 +160,8 @@ export default class TimeNodeStore {
 
   @observable
   updatingBountiesGraphInProgress = false;
+  @observable
+  updatingProcessedTxsGraphInProgress = false;
 
   constructor(eacService, web3Service, keenStore, storageService) {
     this._eacService = eacService;
@@ -302,6 +304,7 @@ export default class TimeNodeStore {
 
           case EAC_WORKER_MESSAGE_TYPES.PROCESSED_TXS:
             getValuesIfInMessage(['processedTxs']);
+            this.updatingProcessedTxsGraphInProgress = false;
             break;
         }
       };
@@ -483,6 +486,7 @@ export default class TimeNodeStore {
   }
 
   updateProcessedTxsGraph() {
+    this.updatingProcessedTxsGraphInProgress = true;
     this.sendMessageWorker(EAC_WORKER_MESSAGE_TYPES.PROCESSED_TXS);
   }
 

--- a/app/stores/TimeNodeStore.js
+++ b/app/stores/TimeNodeStore.js
@@ -84,6 +84,8 @@ export default class TimeNodeStore {
 
   @observable
   bountiesGraphData = null;
+  @observable
+  processedTxs = null;
 
   @computed
   get nodeStatus() {
@@ -153,6 +155,7 @@ export default class TimeNodeStore {
   updateStatsInterval = null;
   updateBalancesInterval = null;
   updateBountiesGraphInterval = null;
+  updateProcessedTxsInterval = null;
   getNetworkInfoInterval = null;
 
   @observable
@@ -225,6 +228,9 @@ export default class TimeNodeStore {
     this.updateBountiesGraph();
     this.updateBountiesGraphInterval = setInterval(this.updateBountiesGraph, 300000);
 
+    this.updateProcessedTxsGraph();
+    this.updateProcessedTxsGraphInterval = setInterval(this.updateProcessedTxsGraph, 300000);
+
     this.getNetworkInfo();
     this.getNetworkInfoInterval = setInterval(this.getNetworkInfo, 15000);
   }
@@ -292,6 +298,10 @@ export default class TimeNodeStore {
           case EAC_WORKER_MESSAGE_TYPES.BOUNTIES_GRAPH_DATA:
             this.updatingBountiesGraphInProgress = false;
             getValuesIfInMessage(['bountiesGraphData']);
+            break;
+
+          case EAC_WORKER_MESSAGE_TYPES.PROCESSED_TXS:
+            getValuesIfInMessage(['processedTxs']);
             break;
         }
       };
@@ -470,6 +480,10 @@ export default class TimeNodeStore {
   updateBountiesGraph() {
     this.updatingBountiesGraphInProgress = true;
     this.sendMessageWorker(EAC_WORKER_MESSAGE_TYPES.BOUNTIES_GRAPH_DATA);
+  }
+
+  updateProcessedTxsGraph() {
+    this.sendMessageWorker(EAC_WORKER_MESSAGE_TYPES.PROCESSED_TXS);
   }
 
   clearStats() {


### PR DESCRIPTION
**Changelog**
- TimeNodes can now see a new graph that shows the number of transactions that have been processed (executed) each hour for the past 24 hours.
- Changed all graphs to be **bar charts** because the other charts don't match the use

**Screenshot from Ropsten**
![screenshot 2018-10-04 at 22 36 30](https://user-images.githubusercontent.com/9353642/46501536-1a476880-c826-11e8-9aa4-9390e0b9357f.png)
