### PR TITLE
[FEATURE] [ANALYTICS] Total ETH transferred counter

### DIFF
--- a/__mocks__/EacServiceMock.js
+++ b/__mocks__/EacServiceMock.js
@@ -1,0 +1,46 @@
+export const MOCKED_TRANSACTIONS = [
+  '0x123306090abab3a6e1400e9345bc60c78a8bef57',
+  '0x456306090abab3a6e1400e9345bc60c78a8bef57'
+];
+
+export const eacService = {
+  calcEndowment(num) {
+    return num;
+  },
+  getActiveContracts: () => {
+    return {};
+  },
+  requestFactory: () =>
+    Promise.resolve({
+      getRequestCreatedLogs() {
+        return MOCKED_TRANSACTIONS.map(tx => ({
+          args: {
+            request: tx,
+            params: []
+          }
+        }));
+      }
+    }),
+  scheduler: () => Promise.resolve({}),
+
+  transactionRequest(address) {
+    return {
+      address
+    };
+  },
+  getTransactionsEventsForAddresses() {
+    return {};
+  },
+  Util: {
+    getBlockNumber() {
+      return 1;
+    },
+    getTimestampForBlock: () => 123
+  },
+  RequestData() {
+    return {};
+  },
+  getTotalEthTransferred: () => {
+    return 1000;
+  }
+};

--- a/__tests__/App.unit.test.js
+++ b/__tests__/App.unit.test.js
@@ -16,6 +16,8 @@ import DateTimeValidator from '../app/stores/DateTimeValidatorStore';
 import LocalStorageService from '../app/services/storage';
 import LocalStorageMock from '../__mocks__/LocalStorageMock';
 import TokenHelper from '../app/services/token-helper';
+import EacStore from '../app/stores/EacStore';
+import { eacService, MOCKED_TRANSACTIONS } from '../__mocks__/EacServiceMock';
 
 momentDurationFormatSetup(moment);
 
@@ -24,11 +26,6 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('App', () => {
   it('correctly navigates when clicking links', async () => {
     const TEST_EXPLORER = 'https://etherscan.io/';
-
-    const MOCKED_TRANSACTIONS = [
-      '0x123306090abab3a6e1400e9345bc60c78a8bef57',
-      '0x456306090abab3a6e1400e9345bc60c78a8bef57'
-    ];
 
     const web3Service = new Web3Service({
       eth: {
@@ -69,45 +66,6 @@ describe('App', () => {
       connect() {},
       init: () => Promise.resolve(true)
     });
-
-    const eacService = {
-      calcEndowment(num) {
-        return num;
-      },
-      getActiveContracts: () => {
-        return {};
-      },
-      requestFactory: () =>
-        Promise.resolve({
-          getRequestCreatedLogs() {
-            return MOCKED_TRANSACTIONS.map(tx => ({
-              args: {
-                request: tx,
-                params: []
-              }
-            }));
-          }
-        }),
-      scheduler: () => Promise.resolve({}),
-
-      transactionRequest(address) {
-        return {
-          address
-        };
-      },
-      getTransactionsEventsForAddresses() {
-        return {};
-      },
-      Util: {
-        getBlockNumber() {
-          return 1;
-        },
-        getTimestampForBlock: () => 123
-      },
-      RequestData() {
-        return {};
-      }
-    };
 
     const TRANSACTIONS_LENGTH = 20;
 
@@ -180,9 +138,12 @@ describe('App', () => {
 
     const transactionStatistics = {};
 
+    const eacStore = new EacStore(eacService, featuresService, web3Service);
+
     const injectables = {
       dateTimeValidatorStore,
       eacService,
+      eacStore,
       featuresService,
       keenStore,
       scheduleStore,

--- a/__tests__/Header.unit.test.js
+++ b/__tests__/Header.unit.test.js
@@ -11,6 +11,8 @@ import LocalStorageService from '../app/services/storage';
 import LocalStorageMock from '../__mocks__/LocalStorageMock';
 import TimeNodeStore from '../app/stores/TimeNodeStore';
 import { KOVAN_NETWORK_ID } from '../app/config/web3Config';
+import EacStore from '../app/stores/EacStore';
+import { eacService } from '../__mocks__/EacServiceMock';
 
 const browserHistory = createBrowserHistory();
 const routingStore = new RouterStore();
@@ -42,24 +44,21 @@ describe('Header', () => {
     });
 
     const keenStore = {};
-    const eacService = {
-      getActiveContracts: () => {
-        return {};
-      }
-    };
     const featuresService = {};
 
     const storageService = new LocalStorageService(new LocalStorageMock());
     const timeNodeStore = new TimeNodeStore({}, web3Service, {}, storageService);
     const transactionStatistics = {};
 
+    const eacStore = new EacStore(eacService, featuresService, web3Service);
+
     const injectables = {
       featuresService,
       keenStore,
       storageService,
       web3Service,
-      eacService,
       timeNodeStore,
+      eacStore,
       transactionStatistics
     };
 
@@ -87,7 +86,7 @@ describe('Header', () => {
         .html()
         .trim()
     ).toBe(
-      `<div data-test="network-display"><span class="active-timenodes"><i class="fa fa-th-large"></i>&nbsp;Network:&nbsp;</span><span class="timenode-count"><span>Kovan at #${CURRENT_BLOCK}</span></span></div>`
+      `<div data-test="network-display" class="header-item"><span class="analytics-name"><i class="fa fa-th-large"></i>&nbsp;Network:&nbsp;</span><span class="analytics-count"><span>Kovan at #${CURRENT_BLOCK}</span></span></div>`
     );
 
     mockedRender.unmount();

--- a/__tests__/SidePanel.unit.test.js
+++ b/__tests__/SidePanel.unit.test.js
@@ -9,6 +9,8 @@ import { RouterStore, syncHistoryWithStore } from 'mobx-react-router';
 import TimeNodeStore from '../app/stores/TimeNodeStore';
 import LocalStorageMock from '../__mocks__/LocalStorageMock';
 import LocalStorageService from '../app/services/storage';
+import EacStore from '../app/stores/EacStore';
+import { eacService } from '../__mocks__/EacServiceMock';
 
 const browserHistory = createBrowserHistory();
 const routingStore = new RouterStore();
@@ -31,12 +33,16 @@ describe('SidePanel', () => {
 
     const keenStore = {};
     const transactionStatistics = {};
+    const featuresService = {};
 
     const localStorageMock = new LocalStorageMock();
     const storageService = new LocalStorageService(localStorageMock);
     const timeNodeStore = new TimeNodeStore({}, {}, {}, storageService);
 
+    const eacStore = new EacStore(eacService, featuresService, web3Service);
+
     const injectables = {
+      eacStore,
       keenStore,
       timeNodeStore,
       transactionStatistics,

--- a/__tests__/__snapshots__/SidePanel.unit.test.js.snap
+++ b/__tests__/__snapshots__/SidePanel.unit.test.js.snap
@@ -231,7 +231,7 @@ exports[`SidePanel is correctly rendered 1`] = `
         <div
           className="sidebar-additional-item--label"
         >
-          Active TimeNodes
+          Transferred
         </div>
         <div
           className="sidebar-additional-item--display"
@@ -249,7 +249,20 @@ exports[`SidePanel is correctly rendered 1`] = `
               className="css-1ncsqv2"
             />
           </div>
+           ETH
         </div>
+      </li>
+      <li
+        className="sidebar-additional-item"
+      >
+        <div
+          className="sidebar-additional-item--label"
+        >
+          Active TimeNodes
+        </div>
+        <div
+          className="sidebar-additional-item--display"
+        />
       </li>
       <li
         className="sidebar-additional-item"
@@ -277,7 +290,21 @@ exports[`SidePanel is correctly rendered 1`] = `
         </div>
         <div
           className="sidebar-additional-item--display"
-        />
+        >
+          <div
+            className=""
+          >
+            <div
+              className="css-1ncsqv2"
+            />
+            <div
+              className="css-o7y5po"
+            />
+            <div
+              className="css-1ncsqv2"
+            />
+          </div>
+        </div>
       </li>
       <li
         className="sidebar-additional-item"
@@ -302,7 +329,7 @@ exports[`SidePanel is correctly rendered 1`] = `
         <div
           className="sidebar-additional-item--display"
         >
-          undefined%
+           %
         </div>
       </li>
     </ul>

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -13,19 +13,10 @@ import { withRouter } from 'react-router-dom';
 @inject('keenStore')
 @inject('featuresService')
 @inject('timeNodeStore')
+@inject('eacStore')
 @observer
 class Header extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      eacContracts: {},
-      totalEthTransferred: null
-    };
-  }
-
   async componentDidMount() {
-    this.fetchEacInfo();
-
     const $ = window.jQuery;
     if ($) {
       $('[data-toggle="tooltip"]').tooltip();
@@ -37,23 +28,6 @@ class Header extends Component {
     if ($) {
       $('[data-toggle="tooltip"]').tooltip();
     }
-  }
-
-  async fetchEacInfo() {
-    const { web3Service } = this.props;
-    await web3Service.init();
-
-    if (!this.props.featuresService._isCurrentNetworkSupported) {
-      return;
-    }
-
-    const eacContracts = await this.props.eacService.getActiveContracts();
-    const totalEthTransferred = await this.props.eacService.Analytics.getTotalEthTransferred();
-
-    this.setState({
-      eacContracts,
-      totalEthTransferred: Math.round(totalEthTransferred)
-    });
   }
 
   getInfoButton(message) {
@@ -75,7 +49,7 @@ class Header extends Component {
   }
 
   render() {
-    const { web3Service, keenStore, timeNodeStore, transactionStatistics } = this.props;
+    const { web3Service, keenStore, timeNodeStore, transactionStatistics, eacStore } = this.props;
 
     const loaderIfNull = value => (value !== null ? value : <BeatLoader color="#fff" size={4} />);
 
@@ -127,7 +101,7 @@ class Header extends Component {
               </span>
             </span>
             <span className="analytics-count">
-              {loaderIfNull(this.state.totalEthTransferred)}&nbsp;ETH
+              {loaderIfNull(eacStore.totalEthTransferred)}&nbsp;ETH
             </span>
           </div>
 
@@ -211,7 +185,7 @@ class Header extends Component {
                         <div className="d-block text-uppercase font-weight-bold text-dark">
                           Schedulers
                         </div>
-                        {this.state.eacContracts.timestampScheduler && (
+                        {eacStore.contracts.timestampScheduler && (
                           <div className="content">
                             <div className="d-block">Time: </div>
                             <div className="d-block text-ellipsis">
@@ -219,7 +193,7 @@ class Header extends Component {
                                 href={
                                   web3Service.explorer
                                     ? `${web3Service.explorer}/address/${
-                                        this.state.eacContracts.timestampScheduler
+                                        eacStore.contracts.timestampScheduler
                                       }`
                                     : ''
                                 }
@@ -227,12 +201,12 @@ class Header extends Component {
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >
-                                {this.state.eacContracts.timestampScheduler}
+                                {eacStore.contracts.timestampScheduler}
                               </a>
                             </div>
                           </div>
                         )}
-                        {this.state.eacContracts.blockScheduler && (
+                        {eacStore.contracts.blockScheduler && (
                           <div className="content">
                             <div className="d-block">Block: </div>
                             <div className="d-block text-ellipsis">
@@ -240,7 +214,7 @@ class Header extends Component {
                                 href={
                                   web3Service.explorer
                                     ? `${web3Service.explorer}/address/${
-                                        this.state.eacContracts.blockScheduler
+                                        eacStore.contracts.blockScheduler
                                       }`
                                     : ''
                                 }
@@ -248,7 +222,7 @@ class Header extends Component {
                                 target="_blank"
                                 rel="noopener noreferrer"
                               >
-                                {this.state.eacContracts.blockScheduler}
+                                {eacStore.contracts.blockScheduler}
                               </a>
                             </div>
                           </div>
@@ -260,8 +234,8 @@ class Header extends Component {
                         <div className="d-block text-uppercase font-weight-bold text-dark">
                           Libraries
                         </div>
-                        {this.state.eacContracts &&
-                          Object.keys(this.state.eacContracts)
+                        {eacStore.contracts &&
+                          Object.keys(eacStore.contracts)
                             .filter(contract => new RegExp('lib', 'i').test(contract))
                             .map(found => (
                               <div className="content" key={found}>
@@ -271,7 +245,7 @@ class Header extends Component {
                                     href={
                                       web3Service.explorer
                                         ? `${web3Service.explorer}/address/${
-                                            this.state.eacContracts[found]
+                                            eacStore.contracts[found]
                                           }`
                                         : ''
                                     }
@@ -279,7 +253,7 @@ class Header extends Component {
                                     target="_blank"
                                     rel="noopener noreferrer"
                                   >
-                                    {this.state.eacContracts[found]}
+                                    {eacStore.contracts[found]}
                                   </a>
                                 </div>
                               </div>
@@ -319,6 +293,7 @@ Header.propTypes = {
   eacService: PropTypes.any,
   keenStore: PropTypes.any,
   timeNodeStore: PropTypes.any,
+  eacStore: PropTypes.any,
   transactionStatistics: PropTypes.any,
   history: PropTypes.object.isRequired
 };

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -18,12 +18,13 @@ class Header extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      eacContracts: {}
+      eacContracts: {},
+      totalEthTransferred: null
     };
   }
 
   async componentDidMount() {
-    this.fetchEacContracts();
+    this.fetchEacInfo();
 
     const $ = window.jQuery;
     if ($) {
@@ -38,7 +39,7 @@ class Header extends Component {
     }
   }
 
-  async fetchEacContracts() {
+  async fetchEacInfo() {
     const { web3Service } = this.props;
     await web3Service.init();
 
@@ -47,7 +48,12 @@ class Header extends Component {
     }
 
     const eacContracts = await this.props.eacService.getActiveContracts();
-    this.setState({ eacContracts });
+    const totalEthTransferred = await this.props.eacService.Analytics.getTotalEthTransferred();
+
+    this.setState({
+      eacContracts,
+      totalEthTransferred: Math.round(totalEthTransferred)
+    });
   }
 
   getInfoButton(message) {
@@ -99,41 +105,60 @@ class Header extends Component {
           className="btn-link toggle-sidebar d-lg-none pg pg-menu"
           data-toggle="sidebar"
         />
-        <div>
-          <div className="brand inline">
-            <img
-              src="img/logo-white.png"
-              data-src="img/logo-white.png"
-              alt="ChronoLogic"
-              height="36"
-            />
-          </div>
+
+        <div className="brand inline">
+          <img
+            src="img/logo-white.png"
+            data-src="img/logo-white.png"
+            alt="ChronoLogic"
+            height="36"
+          />
         </div>
+
         <div className="header-items">
-          <div>
-            <span className="active-timenodes">
-              <i className="fa fa-sitemap" />
-              <span className="mx-2">Active TimeNodes:</span>
+          <div className="header-item">
+            <span className="analytics-name">
+              <i className="fa fa-exchange-alt" />
+              <span
+                className="mx-2"
+                title="Amount of ETH transferred using the Ethereum Alarm Clock"
+              >
+                Transferred:
+              </span>
             </span>
-            <span className="timenode-count">{displayActiveTimenodes}</span>
+            <span className="analytics-count">
+              {loaderIfNull(this.state.totalEthTransferred)}&nbsp;ETH
+            </span>
           </div>
+
           <div className="header-separator" />
-          <div>
-            &nbsp;
-            <span className="active-timenodes">
+
+          <div className="header-item">
+            <span className="analytics-name">
+              <i className="fa fa-sitemap" />
+              <span className="mx-2">TimeNodes:</span>
+            </span>
+            <span className="analytics-count">{displayActiveTimenodes}</span>
+          </div>
+
+          <div className="header-separator" />
+
+          <div className="header-item">
+            <span className="analytics-name">
               <i className="fa fa-chart-bar" />
               <span className="mx-2" title="Amount of transactions scheduled">
                 Upcoming transactions:
               </span>
             </span>
-            <span className="timenode-count">
+            <span className="analytics-count">
               {loaderIfNull(transactionsScheduledInNextHoursAmount)}
             </span>
           </div>
+
           <div className="header-separator" />
-          <div>
-            &nbsp;
-            <span className="active-timenodes">
+
+          <div className="header-item">
+            <span className="analytics-name">
               <i className="fa fa-check-square" />
               <span
                 className="mx-2"
@@ -142,23 +167,27 @@ class Header extends Component {
                 Efficiency:
               </span>
             </span>
-            <span className="timenode-count">
+            <span className="analytics-count">
               {efficiency === null ? <BeatLoader color="#fff" size={4} /> : `${efficiency}%`}
             </span>
           </div>
+
           <div className="header-separator" />
-          <div data-test="network-display">
-            <span className="active-timenodes">
+
+          <div data-test="network-display" className="header-item">
+            <span className="analytics-name">
               <i className="fa fa-th-large" />
               &nbsp;Network:&nbsp;
             </span>
-            <span className="timenode-count">
+            <span className="analytics-count">
               <NetworkChooser showBlockNumber={true} />
             </span>
           </div>
+
           <div className="header-separator" />
-          <div>
-            <span className="active-timenodes" data-toggle="dropdown" title="Contracts">
+
+          <div className="header-item">
+            <span className="analytics-name" data-toggle="dropdown" title="Contracts">
               <i className="fa fa-file-alt ml-2 cursor-pointer" />
               &nbsp;
             </span>

--- a/app/components/Header/Header.js
+++ b/app/components/Header/Header.js
@@ -9,7 +9,6 @@ import { withRouter } from 'react-router-dom';
 @withRouter
 @inject('transactionStatistics')
 @inject('web3Service')
-@inject('eacService')
 @inject('keenStore')
 @inject('featuresService')
 @inject('timeNodeStore')
@@ -290,7 +289,6 @@ Header.propTypes = {
   featuresService: PropTypes.any,
   updateSearchState: PropTypes.any,
   web3Service: PropTypes.any,
-  eacService: PropTypes.any,
   keenStore: PropTypes.any,
   timeNodeStore: PropTypes.any,
   eacStore: PropTypes.any,

--- a/app/components/SidePanel/SidePanel.js
+++ b/app/components/SidePanel/SidePanel.js
@@ -9,6 +9,7 @@ import NetworkChooser from '../Header/NetworkChooser';
 @inject('transactionStatistics')
 @inject('web3Service')
 @inject('keenStore')
+@inject('eacStore')
 @observer
 class SidePanel extends Component {
   constructor() {
@@ -54,6 +55,8 @@ class SidePanel extends Component {
     const subtitleClasses = 'sub-title ';
     const thumbnailClasses = 'icon-thumbnail ';
 
+    const loaderIfNull = value => (value !== null ? value : <BeatLoader color="#fff" size={4} />);
+
     const entryList = [
       {
         title: 'Schedule',
@@ -79,17 +82,11 @@ class SidePanel extends Component {
     ];
 
     const { isElectron } = this.state;
-    const { keenStore, transactionStatistics, web3Service } = this.props;
+    const { keenStore, transactionStatistics, web3Service, eacStore } = this.props;
 
     const defaultAccount = web3Service.accounts && web3Service.accounts[0];
 
     const myTransactionsLink = `/transactions/owner/${defaultAccount}`;
-
-    const activeTimenodes = keenStore.activeTimeNodes ? (
-      keenStore.activeTimeNodes
-    ) : (
-      <BeatLoader color="#fff" size={4} />
-    );
 
     const infoBtn = (
       <span
@@ -103,7 +100,9 @@ class SidePanel extends Component {
       </span>
     );
 
-    const displayActiveTimenodes = keenStore.isBlacklisted ? infoBtn : activeTimenodes;
+    const displayActiveTimenodes = keenStore.isBlacklisted
+      ? infoBtn
+      : loaderIfNull(keenStore.activeTimeNodes);
 
     const { efficiency, transactionsScheduledInNextHoursAmount } = transactionStatistics;
 
@@ -214,17 +213,16 @@ class SidePanel extends Component {
                 </a>
               </li>
             )}
-            {!isElectron &&
-              !web3Service.isOnMainnet() && (
-                <li>
-                  <NavLink to="/faucet">
-                    <span className={entryList[3].titleClasses}>{entryList[3].title}</span>
-                    <span className={entryList[3].thumbnailClasses}>
-                      <i className="fas fa-tint" />
-                    </span>
-                  </NavLink>
-                </li>
-              )}
+            {!isElectron && !web3Service.isOnMainnet() && (
+              <li>
+                <NavLink to="/faucet">
+                  <span className={entryList[3].titleClasses}>{entryList[3].title}</span>
+                  <span className={entryList[3].thumbnailClasses}>
+                    <i className="fas fa-tint" />
+                  </span>
+                </NavLink>
+              </li>
+            )}
             <li>
               <a
                 href="https://blog.chronologic.network/chronos-platform/home"
@@ -242,6 +240,13 @@ class SidePanel extends Component {
             </li>
 
             <hr className="sidebar-separator mx-4" />
+
+            <li className="sidebar-additional-item">
+              <div className="sidebar-additional-item--label">Transferred</div>
+              <div className="sidebar-additional-item--display">
+                {loaderIfNull(eacStore.totalEthTransferred)}&nbsp;ETH
+              </div>
+            </li>
 
             <li className="sidebar-additional-item">
               <div className="sidebar-additional-item--label">Active TimeNodes</div>
@@ -265,18 +270,14 @@ class SidePanel extends Component {
             <li className="sidebar-additional-item">
               <div className="sidebar-additional-item--label">Upcoming Transactions</div>
               <div className="sidebar-additional-item--display">
-                {transactionsScheduledInNextHoursAmount === null ? (
-                  <BeatLoader color="#fff" size={4} />
-                ) : (
-                  transactionsScheduledInNextHoursAmount
-                )}
+                {loaderIfNull(transactionsScheduledInNextHoursAmount)}
               </div>
             </li>
 
             <li className="sidebar-additional-item">
               <div className="sidebar-additional-item--label">Efficiency</div>
               <div className="sidebar-additional-item--display">
-                {efficiency === null ? <BeatLoader color="#fff" size={4} /> : `${efficiency}%`}
+                {loaderIfNull(efficiency)}&nbsp;%
               </div>
             </li>
           </ul>
@@ -290,6 +291,7 @@ class SidePanel extends Component {
 SidePanel.propTypes = {
   web3Service: PropTypes.any,
   keenStore: PropTypes.any,
+  eacStore: PropTypes.any,
   location: PropTypes.object.isRequired,
   transactionStatistics: PropTypes.any
 };

--- a/app/components/SidePanel/SidePanel.js
+++ b/app/components/SidePanel/SidePanel.js
@@ -263,7 +263,7 @@ class SidePanel extends Component {
             <li className="sidebar-additional-item">
               <div className="sidebar-additional-item--label">Current Block</div>
               <div className="sidebar-additional-item--display">
-                {this.props.web3Service.latestBlockNumber}
+                {loaderIfNull(web3Service.latestBlockNumber)}
               </div>
             </li>
 

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -67,6 +67,11 @@ $warning-color: gold;
       }
     }
   }
+
+  &-item {
+    margin: 0px 4px;
+    white-space: nowrap;
+  }
 }
 
 .loading-icon {
@@ -307,12 +312,11 @@ hr {
   }
 }
 
-
-.active-timenodes {
+.analytics-name {
   color: $primary-color;
 }
 
-.timenode-count {
+.analytics-count {
   color: #fff;
 
   & > div {

--- a/app/scss/style.scss
+++ b/app/scss/style.scss
@@ -461,6 +461,10 @@ hr {
     flex-grow: 1;
     text-align: right;
     color: white;
+
+    & > div {
+      display: inline;
+    }
   }
 }
 

--- a/app/stores/EacStore.js
+++ b/app/stores/EacStore.js
@@ -1,0 +1,30 @@
+import { autorun, observable } from 'mobx';
+
+export default class EacStore {
+  @observable
+  contracts = {};
+
+  @observable
+  totalEthTransferred = null;
+
+  constructor(eacService, featuresService, web3Service) {
+    this._eac = eacService;
+    this._featuresService = featuresService;
+    this._web3Service = web3Service;
+
+    autorun(() => this.refreshCurrentState());
+  }
+
+  async refreshCurrentState() {
+    if (!this._featuresService._isCurrentNetworkSupported) {
+      return;
+    }
+
+    await this._web3Service.init();
+
+    this.contracts = await this._eac.getActiveContracts();
+
+    const totalEthTransferred = await this._eac.Analytics.getTotalEthTransferred();
+    this.totalEthTransferred = Math.round(totalEthTransferred);
+  }
+}

--- a/app/stores/index.js
+++ b/app/stores/index.js
@@ -12,6 +12,7 @@ import TransactionHelper from '../services/transaction-helper';
 import BucketHelper from '../services/bucket-helper';
 import { TransactionStatistics } from './TransactionStatistics';
 import LoadingStateStore from './LoadingStateStore';
+import EacStore from './EacStore';
 
 const {
   eacService,
@@ -68,8 +69,11 @@ export const history = syncHistoryWithStore(browserHistory, routingStore);
 
 const loadingStateStore = new LoadingStateStore(web3Service, featuresService, transactionStore);
 
+export const eacStore = new EacStore(eacService, featuresService, web3Service);
+
 export const stores = {
   dateTimeValidatorStore,
+  eacStore,
   loadingStateStore,
   keenStore,
   routing: routingStore,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eth-alarm-clock-dapp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION

![screenshot 2018-11-13 at 08 46 43](https://user-images.githubusercontent.com/9353642/48398454-16f6a500-e721-11e8-8434-2cadc4deff08.png)
![screenshot 2018-11-13 at 08 46 01](https://user-images.githubusercontent.com/9353642/48398464-1b22c280-e721-11e8-8705-b547a0a7c61c.png)

**New** 
- `EacStore` - Stores information about the total ETH transferred count + info about contracts
- Replaced `&nbsp;` on starts and ends of divs with `margin` CSS styling
- Add missing loader to Block Number analytics