### PR TITLE
[FEATURE] Show transaction details faster after scheduling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,8 @@
         "no-extra-semi": "error",
         "semi": ["error", "always"],
         "quotes": ["error", "single", { "allowTemplateLiterals": true }],
-        "jsx-quotes": ["error", "prefer-double"]
+        "jsx-quotes": ["error", "prefer-double"],
+        "no-console": 0
     },
     "plugins": ["jest"],
     "settings": {

--- a/app/components/TransactionScanner/TransactionDetails.js
+++ b/app/components/TransactionScanner/TransactionDetails.js
@@ -326,12 +326,15 @@ class TransactionDetails extends Component {
 
     const status = await transactionStore.getTxStatus(transaction, moment().unix());
 
+    const statePropertiesToSet = {
+      status
+    };
+
     if (!transactionMissingData) {
-      this.setState({
-        callData: await transaction.callData(),
-        status
-      });
+      statePropertiesToSet.callData = await transaction.callData();
     }
+
+    this.setState(statePropertiesToSet);
 
     await this.getFrozenStatus();
     await this.testToken();

--- a/app/components/TransactionScanner/TransactionDetails.js
+++ b/app/components/TransactionScanner/TransactionDetails.js
@@ -322,7 +322,7 @@ class TransactionDetails extends Component {
   }
 
   async setupDetails() {
-    const { transaction, transactionStore } = this.props;
+    const { transaction, transactionStore, transactionMissingData } = this.props;
 
     const status = await transactionStore.getTxStatus(transaction, moment().unix());
 
@@ -339,6 +339,11 @@ class TransactionDetails extends Component {
     this.setState(statePropertiesToSet);
 
     await this.getFrozenStatus();
+
+    if (transactionMissingData) {
+      return;
+    }
+
     await this.testToken();
     await this.executedAt(transaction, status, transactionStore);
     await this.fetchTokenTransferEvents();
@@ -431,7 +436,13 @@ class TransactionDetails extends Component {
   }
 
   getTokenNotificationSection() {
-    const { status, isFrozen, isTokenTransfer, tokenTransferApproved } = this.state;
+    const {
+      status,
+      isFrozen,
+      isTokenTransfer,
+      tokenTransferApproved,
+      transactionMissingData
+    } = this.state;
     const { transaction } = this.props;
 
     const isOwner = this.isOwner(transaction);
@@ -442,6 +453,7 @@ class TransactionDetails extends Component {
     );
 
     if (
+      !transactionMissingData &&
       isOwner &&
       tokenTransferApproved === false &&
       isTokenTransfer &&

--- a/app/components/TransactionScanner/TransactionDetails.js
+++ b/app/components/TransactionScanner/TransactionDetails.js
@@ -334,6 +334,7 @@ class TransactionDetails extends Component {
       statePropertiesToSet.callData = await transaction.callData();
     } catch (error) {
       statePropertiesToSet.callData = '';
+      console.error('Error from TransactionDetails:', error);
     }
 
     this.setState(statePropertiesToSet);

--- a/app/components/TransactionScanner/TransactionDetails.js
+++ b/app/components/TransactionScanner/TransactionDetails.js
@@ -499,6 +499,8 @@ class TransactionDetails extends Component {
 
     const tokenTransferApprovalStatus = tokenTransferApproved ? 'Approved' : 'Not Approved';
 
+    const loader = <BeatLoader size={6} color="#aaa" />;
+
     return (
       <div className="tab-pane slide active show">
         {this.getTokenNotificationSection()}
@@ -514,7 +516,7 @@ class TransactionDetails extends Component {
             <tr className="row">
               <td className="d-inline-block col-5 col-md-3">Status</td>
               <td className="d-inline-block col-7 col-md-9">
-                {status ? status : <BeatLoader size={6} color="#aaa" />}
+                {status ? status : loader}
                 {executedAt ? (
                   <span>
                     {` at `}
@@ -535,11 +537,7 @@ class TransactionDetails extends Component {
               <tr className="row">
                 <td className="d-inline-block col-5 col-md-3">Approval status</td>
                 <td className="d-inline-block col-7 col-md-9">
-                  {tokenTransferApproved === undefined ? (
-                    <BeatLoader size={6} color="#aaa" />
-                  ) : (
-                    tokenTransferApprovalStatus
-                  )}
+                  {tokenTransferApproved === undefined ? loader : tokenTransferApprovalStatus}
                 </td>
               </tr>
             )}
@@ -553,7 +551,7 @@ class TransactionDetails extends Component {
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  {toAddress || <BeatLoader size={6} color="#aaa" />}
+                  {toAddress || loader}
                 </a>
               </td>
             </tr>
@@ -588,7 +586,7 @@ class TransactionDetails extends Component {
             <tr className="row">
               <td className="d-inline-block col-5 col-md-3">Data</td>
               <td className="d-inline-block col-7 col-md-9" title={callData}>
-                {callData || <BeatLoader size={6} color="#aaa" />}
+                {callData || loader}
               </td>
             </tr>
             <tr className="row">

--- a/app/components/TransactionsRoute/TransactionDetailsRoute.js
+++ b/app/components/TransactionsRoute/TransactionDetailsRoute.js
@@ -69,11 +69,22 @@ class TransactionDetailsRoute extends Component {
 
     const transaction = await transactionStore.getTransactionByAddress(address);
 
-    await transaction.fillData();
+    try {
+      await transaction.fillData();
+    } catch (error) {
+      this.setState({
+        transaction,
+        transactionNotFound: true,
+        transactionMissingData: false
+      });
 
-    let transactionNoBasicData = this.transactionHasNoBasicData(transaction);
+      return;
+    }
 
-    if (transactionNoBasicData) {
+    let transactionHasNoBasicData = this.transactionHasNoBasicData(transaction);
+    let transactionMissingData = false;
+
+    if (transactionHasNoBasicData) {
       const requestCreatedLog = transactionCache.requestCreatedLogs.find(
         l => l.args.request === transaction.address
       );
@@ -81,7 +92,8 @@ class TransactionDetailsRoute extends Component {
       if (requestCreatedLog) {
         transactionStore.fillTransactionDataFromRequestCreatedEvent(transaction, requestCreatedLog);
 
-        transactionNoBasicData = this.transactionHasNoBasicData(transaction);
+        transactionHasNoBasicData = this.transactionHasNoBasicData(transaction);
+        transactionMissingData = true;
       }
     }
 
@@ -91,8 +103,8 @@ class TransactionDetailsRoute extends Component {
 
     this.setState({
       transaction,
-      transactionNotFound: transactionNoBasicData,
-      transactionMissingData: this.transactionMissingData(transaction)
+      transactionNotFound: transactionHasNoBasicData,
+      transactionMissingData
     });
   }
 

--- a/app/services/web3.js
+++ b/app/services/web3.js
@@ -64,6 +64,21 @@ export default class Web3Service {
     return await Bb.fromCallback(callback => this.web3.eth.getTransactionReceipt(hash, callback));
   }
 
+  async waitForMining(hash) {
+    let receipt;
+
+    while (!receipt || !receipt.blockNumber) {
+      await new Promise(resolve => {
+        setTimeout(async () => {
+          receipt = await this.fetchReceipt(hash);
+          resolve();
+        }, 500);
+      });
+    }
+
+    return receipt;
+  }
+
   async fetchLog(hash, event) {
     const receipt = await this.trackTransaction(hash);
     let Log;

--- a/app/stores/TransactionCache.js
+++ b/app/stores/TransactionCache.js
@@ -97,7 +97,7 @@ export default class TransactionCache {
     }
   }
 
-  addRequestCreatedLogToCache(log) {
+  addRequestCreatedLogToCache(log, skipUpdatingEndBlock = false) {
     const logs = this._storage.load(REQUEST_LOGS_CACHE_KEY);
     let newLogs;
 
@@ -114,7 +114,10 @@ export default class TransactionCache {
     }
 
     this._storage.save(REQUEST_LOGS_CACHE_KEY, JSON.stringify(newLogs));
-    this._storage.save(REQUEST_LOGS_END_BLOCK_CACHE_KEY, log.blockNumber);
+
+    if (!skipUpdatingEndBlock) {
+      this._storage.save(REQUEST_LOGS_END_BLOCK_CACHE_KEY, log.blockNumber);
+    }
 
     this.loadRequestCreatedLogsFromStorage();
   }


### PR DESCRIPTION
a) Scheduling when staying on the same page: https://youtu.be/aaR345cLIXk
Here we take advantage of local data from scheduling view (we save it in memory, until tab is closed)

b) Scheduling when transaction has been scheduled in different tab (no local data): 
https://youtu.be/a0M2rPkp8c0 